### PR TITLE
Fix a typo: s/pyroperty/property

### DIFF
--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -1056,7 +1056,7 @@ static VALUE rxml_node_attributes_get(VALUE self)
  *    node.property("name") -> "string"
  *    node["name"]          -> "string"
  *
- * Obtain the named pyroperty.
+ * Obtain the named property.
  */
 static VALUE rxml_node_attribute_get(VALUE self, VALUE name)
 {


### PR DESCRIPTION
Fix a small typo in the rdoc.
