### PR TITLE
Add XPath expression <-> Ruby value conversion methods.

### DIFF
--- a/ext/libxml/ruby_xml_xpath.c
+++ b/ext/libxml/ruby_xml_xpath.c
@@ -78,6 +78,85 @@
 
 VALUE mXPath;
 
+VALUE
+rxml_xpath_to_value(xmlXPathContextPtr xctxt, xmlXPathObjectPtr xobject) {
+  VALUE result;
+
+  if (xobject == NULL) {
+    /* xmlLastError is different than xctxt->lastError.  Use
+     xmlLastError since it has the message set while xctxt->lastError
+     does not. */
+    xmlErrorPtr xerror = xmlGetLastError();
+    rxml_raise(xerror);
+  }
+
+  switch (xobject->type) {
+    case XPATH_NODESET:
+      result = rxml_xpath_object_wrap(xctxt->doc, xobject);
+      break;
+    case XPATH_BOOLEAN:
+      result = (xobject->boolval != 0) ? Qtrue : Qfalse;
+      xmlXPathFreeObject(xobject);
+      break;
+    case XPATH_NUMBER:
+      result = rb_float_new(xobject->floatval);
+      xmlXPathFreeObject(xobject);
+      break;
+    case XPATH_STRING:
+      result = rxml_str_new2((const char*)xobject->stringval, xctxt->doc->encoding);
+      xmlXPathFreeObject(xobject);
+      break;
+    default:
+      result = Qnil;
+      xmlXPathFreeObject(xobject);
+  }
+
+  return result;
+}
+
+xmlXPathObjectPtr
+rxml_xpath_from_value(VALUE value) {
+  xmlXPathObjectPtr result = NULL;
+
+  switch (TYPE(value)) {
+    case T_TRUE:
+    case T_FALSE:
+      result = xmlXPathNewBoolean(RTEST(value));
+      break;
+    case T_FIXNUM:
+    case T_FLOAT:
+      result = xmlXPathNewFloat(NUM2DBL(value));
+      break;
+    case T_STRING:
+      result = xmlXPathWrapString(xmlStrdup((const xmlChar *)StringValuePtr(value)));
+      break;
+    case T_NIL:
+      result = xmlXPathNewNodeSet(NULL);
+      break;
+    case T_ARRAY: {
+      int i, j;
+      result = xmlXPathNewNodeSet(NULL);
+
+      for (i = RARRAY_LEN(value); i > 0; i--) {
+        xmlXPathObjectPtr obj = rxml_xpath_from_value(rb_ary_shift(value));
+
+        if ((obj->nodesetval != NULL) && (obj->nodesetval->nodeNr != 0)) {
+          for (j = 0; j < obj->nodesetval->nodeNr; j++) {
+            xmlXPathNodeSetAdd(result->nodesetval, obj->nodesetval->nodeTab[j]);
+          }
+        }
+      }
+      break;
+    }
+    default:
+      rb_raise(rb_eTypeError,
+        "can't convert object of type %s to XPath object", rb_obj_classname(value)
+      );
+  }
+
+  return result;
+}
+
 void rxml_init_xpath(void)
 {
   mXPath = rb_define_module_under(mXML, "XPath");

--- a/ext/libxml/ruby_xml_xpath.h
+++ b/ext/libxml/ruby_xml_xpath.h
@@ -5,6 +5,9 @@
 
 extern VALUE mXPath;
 
+extern VALUE rxml_xpath_to_value(xmlXPathContextPtr, xmlXPathObjectPtr);
+extern xmlXPathObjectPtr rxml_xpath_from_value(VALUE);
+
 void rxml_init_xpath(void);
 
 #endif

--- a/ext/libxml/ruby_xml_xpath_context.c
+++ b/ext/libxml/ruby_xml_xpath_context.c
@@ -264,7 +264,6 @@ static VALUE rxml_xpath_context_find(VALUE self, VALUE xpath_expr)
   xmlXPathContextPtr xctxt;
   xmlXPathObjectPtr xobject;
   xmlXPathCompExprPtr xcompexpr;
-  VALUE result;
 
   Data_Get_Struct(self, xmlXPathContext, xctxt);
 
@@ -284,37 +283,7 @@ static VALUE rxml_xpath_context_find(VALUE self, VALUE xpath_expr)
         "Argument should be an intance of a String or XPath::Expression");
   }
 
-  if (xobject == NULL)
-  {
-    /* xmlLastError is different than xctxt->lastError.  Use
-     xmlLastError since it has the message set while xctxt->lastError
-     does not. */
-    xmlErrorPtr xerror = xmlGetLastError();
-    rxml_raise(xerror);
-  }
-
-  switch (xobject->type)
-  {
-  case XPATH_NODESET:
-    result = rxml_xpath_object_wrap(xctxt->doc, xobject);
-    break;
-  case XPATH_BOOLEAN:
-    result = (xobject->boolval != 0) ? Qtrue : Qfalse;
-    xmlXPathFreeObject(xobject);
-    break;
-  case XPATH_NUMBER:
-    result = rb_float_new(xobject->floatval);
-    xmlXPathFreeObject(xobject);
-    break;
-  case XPATH_STRING:
-    result = rxml_str_new2((const char*)xobject->stringval, xctxt->doc->encoding);
-    xmlXPathFreeObject(xobject);
-    break;
-  default:
-    result = Qnil;
-    xmlXPathFreeObject(xobject);
-  }
-  return result;
+  return rxml_xpath_to_value(xctxt, xobject);
 }
 
 #if LIBXML_VERSION >= 20626


### PR DESCRIPTION
As discussed in xml4r/libxslt-ruby#1:
- Extracted `rxml_xpath_to_value` from `rxml_xpath_context_find`.
- Adapted `rxml_xpath_from_value` from @glejeune's [ruby-xslt](https://github.com/glejeune/ruby-xslt/blob/master/ext/xslt_lib/extfunc.c).

I didn't actually modify the code from `rxml_xpath_context_find`, but I'd like to propose that instead of returning `nil` it raises an error when it's passed an unsupported type. What do you think? Are there any compatibility issues?
