### PR TITLE
Node#content= encoding

### DIFF
--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -397,11 +397,12 @@ static VALUE rxml_node_content_get(VALUE self)
 static VALUE rxml_node_content_set(VALUE self, VALUE content)
 {
   xmlNodePtr xnode;
+  xmlChar* encoded_content;
 
   Check_Type(content, T_STRING);
   xnode = rxml_get_xnode(self);
-  // XXX docs indicate need for escaping entites, need to be done? danj
-  xmlNodeSetContent(xnode, (xmlChar*) StringValuePtr(content));
+  encoded_content = xmlEncodeSpecialChars(xnode->doc, (xmlChar*) StringValuePtr(content));
+  xmlNodeSetContent(xnode, encoded_content);
   return (Qtrue);
 }
 

--- a/test/tc_node.rb
+++ b/test/tc_node.rb
@@ -206,4 +206,11 @@ class TestNode < Test::Unit::TestCase
     text_node = node.first
     assert(text_node.empty?)
   end
+
+  def test_set_content
+    node = XML::Node.new('test')
+    node.content = "unescaped & string"
+    assert_equal("unescaped & string", node.content)
+    assert_equal("<test>unescaped &amp; string</test>", node.to_s)
+  end
 end


### PR DESCRIPTION
`// XXX docs indicate need for escaping entites, need to be done? danj` fixed.

Before:

``` ruby
node.content = "unescaped & string"
node.content #=> "unescaped "
```

After:

``` ruby
node.content = "unescaped & string"
node.content #=> "unescaped & string"
node.to_s #=> "<node>unescaped &amp; string</node>"
```
