### PR TITLE
Fix potential segfault when GC occurs while creating ns from xpath

### DIFF
--- a/ext/libxml/ruby_xml_xpath_object.c
+++ b/ext/libxml/ruby_xml_xpath_object.c
@@ -59,9 +59,10 @@ VALUE rxml_xpath_object_wrap(xmlDocPtr xdoc, xmlXPathObjectPtr xpop)
 {
   int i;
   rxml_xpath_object *rxpop = ALLOC(rxml_xpath_object);
+  /* Make sure Ruby's GC can find the array in the stack */
+  VALUE nsnodes = rb_ary_new();
   rxpop->xdoc =xdoc;
   rxpop->xpop = xpop;
-  rxpop->nsnodes = rb_ary_new();
 
   /* Find all the extra namespace nodes and wrap them. */
   if (xpop->nodesetval && xpop->nodesetval->nodeNr)
@@ -83,11 +84,12 @@ VALUE rxml_xpath_object_wrap(xmlDocPtr xdoc, xmlXPathObjectPtr xpop)
            namespace nodes will not be freed */
         ns = rxml_namespace_wrap((xmlNsPtr)xnode);
         RDATA(ns)->dfree = (RUBY_DATA_FUNC)rxml_xpath_namespace_free;
-        rb_ary_push(rxpop->nsnodes, ns);
+        rb_ary_push(nsnodes, ns);
       }
     }
   }
 
+  rxpop->nsnodes = nsnodes;
   return Data_Wrap_Struct(cXMLXPathObject, rxml_xpath_object_mark, rxml_xpath_object_free, rxpop);
 }
 

--- a/test/tc_xpath.rb
+++ b/test/tc_xpath.rb
@@ -30,6 +30,18 @@ class TestXPath < Test::Unit::TestCase
     assert_equal(3, nodes.length)
   end
 
+  def test_ns_gc
+    _stress = GC.stress
+    GC.stress = true
+
+    doc = XML::Document.string('<foo xmlns="http://bar.com" />')
+    node = doc.root
+    # This line segfaults on prior versions of libxml-ruby
+    node.find("namespace::*")
+
+    GC.stress = _stress
+  end
+
   def test_ns_array
     nodes = @doc.find('//ns1:IdAndName', ['ns1:http://domain.somewhere.com'])
     assert_equal(3, nodes.length)


### PR DESCRIPTION
rxml_xpath_object_wrap() was creating a Ruby array and it looks like
Ruby's garbage collection was unable to find it on the stack.

The segfault triggers consistently for me with ruby 1.9.3-p392
