### PR TITLE
Equality check of LibXML::XML::Error

### DIFF
--- a/lib/libxml/error.rb
+++ b/lib/libxml/error.rb
@@ -52,6 +52,8 @@ module LibXML
         self.int2 == other.int2 and
         self.ctxt == other.ctxt and
         self.node == other.node
+      rescue
+        false
       end
 
       def level_to_s


### PR DESCRIPTION
Currently `LibXML::XML::Error#eql?` method makes certain assumptions about the intefrace of the `other` object.

When the `other` object does not implement assumed interface, `NoMethodError` will be raised, when it would be more logical to return `false` instead indicating that the two objects are not equal.
