### PR TITLE
XML::Error.set_handler doesn't work for background threads.

### DIFF
--- a/test/tc_parser.rb
+++ b/test/tc_parser.rb
@@ -353,4 +353,29 @@ class TestParser < Test::Unit::TestCase
     assert_instance_of(XML::Document, doc)
     assert_instance_of(XML::Parser::Context, parser.context)
   end
+
+  def test_errors_from_background_thread
+    errors = []
+    background_errors = []
+
+    begin
+      XML::Error.set_handler do |error|
+        errors << error
+      end
+      parser = XML::Parser.string("<moo>")
+
+      thread = Thread.new do
+        XML::Error.set_handler do |error|
+          background_errors << error
+        end
+        parser.parse rescue nil
+      end
+      thread.join
+    ensure
+      XML::Error.set_handler(&XML::Error::QUIET_HANDLER)
+    end
+
+    assert_equal(errors.size, 0)
+    assert_equal(background_errors.size, 1)
+  end
 end


### PR DESCRIPTION
Calling XML::Error.set_handler seems to have no affect when you're not on the main thread. I can't seem to set error handlers for things running on background threads at all really :(

I have:

``` shell
$ xmllint --version
xmllint: using libxml version 20708
   compiled with: Threads Tree Output Push Reader Patterns Writer SAXv1 FTP HTTP DTDValid HTML Legacy C14N Catalog XPath XPointer XInclude ISO8859X Unicode Regexps Automata Expr Schemas Schematron Modules Debug Zlib
$ ruby -rubygems -rxml -e 'puts XML::VERSION'
2.6.0
$ ruby --version
ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-darwin12.3.0]
```

Running:

``` ruby
require 'xml'

borked_xml = <<EOXML
<container>
  <not-closed-element>
</container>
EOXML

errors = []
other_errors = []

XML::Error.set_handler do |error|
  errors << error
end
parser = XML::Parser.string(borked_xml)

begin
  t = Thread.new do
    XML::Error.set_handler do |error|
      other_errors << error
    end
    parser.parse
  end
  t.join
rescue XML::Error => e
end

$stderr.puts "I have #{errors.size} errors"
$stderr.puts "I have #{other_errors.size} other errors"
```

I get:

``` shell
$ ./xml-test.rb
Entity: line 3: parser error : Opening and ending tag mismatch: not-closed-element line 2 and container
</container>
            ^
Entity: line 4: parser error : Premature end of data in tag container line 1

^
I have 0 errors
I have 0 other errors
```

Haven't dug around the C-bindings much, but [the libxml error api docs](http://www.xmlsoft.org/html/libxml-xmlerror.html) make allusions that error handling is thread-local.
