### PR TITLE
fix tests for nil TypeErrors for ruby 2.0=<

### DIFF
--- a/test/tc_html_parser.rb
+++ b/test/tc_html_parser.rb
@@ -30,7 +30,7 @@ class HTMLParserTest < Test::Unit::TestCase
       XML::HTMLParser.file(nil)
     end
 
-    assert_equal("can't convert nil into String", error.to_s)
+    assert_match(/nil into String/, error.to_s)
   end
 
   def test_io

--- a/test/tc_parser.rb
+++ b/test/tc_parser.rb
@@ -59,7 +59,7 @@ class TestParser < Test::Unit::TestCase
       XML::Parser.file(nil)
     end
 
-    assert_equal("can't convert nil into String", error.to_s)
+    assert_match(/nil into String/, error.to_s)
   end
 
   def test_file_encoding

--- a/test/tc_sax_parser.rb
+++ b/test/tc_sax_parser.rb
@@ -144,7 +144,7 @@ class TestSaxParser < Test::Unit::TestCase
       XML::SaxParser.file(nil)
     end
 
-    assert_equal("can't convert nil into String", error.to_s)
+    assert_match(/nil into String/, error.to_s)
   end
 
   def test_io


### PR DESCRIPTION
The text for nil to string conversions has gone from:

$ ruby -e '"" + nil rescue puts $!' can't convert nil into String

to:

$ ruby -e '"" + nil rescue puts $!' no implicit conversion of nil into String
