### PR TITLE
During a GC cycle one should not call back into Ruby land

### DIFF
--- a/ext/libxml/ruby_xml_dtd.c
+++ b/ext/libxml/ruby_xml_dtd.c
@@ -47,7 +47,6 @@ void rxml_dtd_mark(xmlDtdPtr xdtd)
 
   if (xdtd->_private == NULL)
   {
-    rb_warning("XmlNode is not bound! (%s:%d)", __FILE__, __LINE__);
     return;
   }
 


### PR DESCRIPTION
In MRI you get away with this since rb_warning is all implemented in C
and probably doesn't allocate any objects itself. In Rubinius rb_warning
is actually implemented in Ruby.

This causes an issue because now it tries to call back into Ruby land
while a GC phase is running that does not allow for concurrency.

Since rb_warning gives you no guarantees about it's implementation, it
should not be called from a GC mark function since this exposes
undefined behavior.

If a warning must be printed here, it's probably better to manually
print to stderr.
