### PR TITLE
Don't mark nodes that aren't handled by ruby

### DIFF
--- a/ext/libxml/ruby_xml_attr.c
+++ b/ext/libxml/ruby_xml_attr.c
@@ -32,22 +32,14 @@
 
 VALUE cXMLAttr;
 
-void rxml_attr_mark(xmlAttrPtr xattr)
-{
-  /* This can happen if Ruby does a GC run after creating the
-     new attribute but before initializing it. */
-  if (xattr != NULL)
-    rxml_node_mark((xmlNodePtr) xattr);
-}
-
 VALUE rxml_attr_wrap(xmlAttrPtr xattr)
 {
-  return Data_Wrap_Struct(cXMLAttr, rxml_attr_mark, NULL, xattr);
+  return Data_Wrap_Struct(cXMLAttr, NULL, NULL, xattr);
 }
 
 static VALUE rxml_attr_alloc(VALUE klass)
 {
-  return Data_Wrap_Struct(klass, rxml_attr_mark, NULL, NULL);
+  return Data_Wrap_Struct(klass, NULL, NULL, NULL);
 }
 
 /*

--- a/ext/libxml/ruby_xml_attr_decl.c
+++ b/ext/libxml/ruby_xml_attr_decl.c
@@ -13,14 +13,9 @@
 
 VALUE cXMLAttrDecl;
 
-void rxml_attr_decl_mark(xmlAttributePtr xattr)
-{
-  rxml_node_mark((xmlNodePtr) xattr);
-}
-
 VALUE rxml_attr_decl_wrap(xmlAttributePtr xattr)
 {
-  return Data_Wrap_Struct(cXMLAttrDecl, rxml_attr_decl_mark, NULL, xattr);
+  return Data_Wrap_Struct(cXMLAttrDecl, NULL, NULL, xattr);
 }
 
 /*

--- a/ext/libxml/ruby_xml_attributes.c
+++ b/ext/libxml/ruby_xml_attributes.c
@@ -32,17 +32,12 @@
 
 VALUE cXMLAttributes;
 
-void rxml_attributes_mark(xmlNodePtr xnode)
-{
-  rxml_node_mark(xnode);
-}
-
 /*
  * Creates a  new attributes instance.  Not exposed to ruby.
  */
 VALUE rxml_attributes_new(xmlNodePtr xnode)
 {
-  return Data_Wrap_Struct(cXMLAttributes, rxml_attributes_mark, NULL, xnode);
+  return Data_Wrap_Struct(cXMLAttributes, NULL, NULL, xnode);
 }
 
 /*


### PR DESCRIPTION
Don't register with a GC mark callback for node types that don't
have node->_private. This fixes a crash that occures if rxml_node_mark is
called with a pointer to a node that has already been freed by libxml.

Unfortunately i can't provide any compact test case / way to reproduce this bug
and prove the fix. However it works for our needs.
