### PR TITLE
Rename gem from libxml-ruby to libxml

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,7 +27,7 @@ includes an already built extension.
 == INSTALLATION
 The easiest way to install libxml-ruby is via Ruby Gems.  To install:
 
-<tt>gem install libxml-ruby</tt>
+<tt>gem install libxml</tt>
 
 If you are running Windows, make sure to install the Win32 RubyGem
 which includes prebuilt extensions for Ruby 1.8, 1.9 and 2.0 preview.  These

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require "rubygems/package_task"
 require "rdoc/task"
 require "yaml"
 
-GEM_NAME = "libxml-ruby"
+GEM_NAME = "libxml"
 SO_NAME  = "libxml_ruby"
 
 # Read the spec file

--- a/libxml.gemspec
+++ b/libxml.gemspec
@@ -4,7 +4,7 @@
 version = File.read('ext/libxml/ruby_xml_version.h').match(/\s*RUBY_LIBXML_VERSION\s*['"](\d.+)['"]/)[1]
 
 Gem::Specification.new do |spec|
-  spec.name        = 'libxml-ruby'
+  spec.name        = 'libxml'
   spec.version     = version
   spec.homepage    = 'http://xml4r.github.com/libxml-ruby'
   spec.summary     = 'Ruby Bindings for LibXML2'
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/libxml/extconf.rb"]
   spec.files = Dir.glob(['HISTORY',
                          'LICENSE',
-                         'libxml-ruby.gemspec',
+                         'libxml.gemspec',
                          'MANIFEST',
                          'Rakefile',
                          'README.rdoc',

--- a/script/benchmark/parsecount
+++ b/script/benchmark/parsecount
@@ -86,7 +86,7 @@ if RUBY_PLATFORM =~ /java/
     gem 'nokogiri', '>= 1.0.6'
     require 'nokogiri'
 
-    gem 'libxml-ruby', '>= 0.9.2'
+    gem 'libxml', '>= 0.9.2'
     require 'libxml'
     @xml_parser = LibXML::XML::Parser.new
 end


### PR DESCRIPTION
It makes sense for this repository to be named `libxml-ruby`, to avoid ambiguity with other XML libraries, but the gem name need not include `-ruby`, since the `rubygems` package manager is tightly coupled to the Ruby language. Just as the [`sqlite3-ruby` gem was renamed to `sqlite`](https://github.com/sparklemotion/sqlite3-ruby/commit/59855b543f2506829403c1d91f9c93c84298ade0), this package’s name should just be `libxml`.

This also increases consistency between the library’s name and the way it is required.

``` ruby
require 'libxml'
```
