### PR TITLE
Fix compile error with debug not enabled in libxml

### DIFF
--- a/ext/libxml/ruby_xml_document.c
+++ b/ext/libxml/ruby_xml_document.c
@@ -475,7 +475,7 @@ static VALUE rxml_document_debug(VALUE self)
   xmlDebugDumpDocument(NULL, xdoc);
   return Qtrue;
 #else
-  rb_warn("libxml was compiled without debugging support.")
+  rb_warn("libxml was compiled without debugging support.");
   return Qfalse;
 #endif
 }

--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -450,7 +450,7 @@ static VALUE rxml_node_debug(VALUE self)
   xmlDebugDumpNode(NULL, xnode, 2);
   return Qtrue;
 #else
-  rb_warn("libxml was compiled without debugging support.")
+  rb_warn("libxml was compiled without debugging support.");
   return Qfalse;
 #endif
 }

--- a/ext/libxml/ruby_xml_xpath_object.c
+++ b/ext/libxml/ruby_xml_xpath_object.c
@@ -312,7 +312,7 @@ static VALUE rxml_xpath_object_debug(VALUE self)
   xmlXPathDebugDumpObject(stdout, rxpop->xpop, 0);
   return Qtrue;
 #else
-  rb_warn("libxml was compiled without debugging support.")
+  rb_warn("libxml was compiled without debugging support.");
   return Qfalse;
 #endif
 }


### PR DESCRIPTION
Due to syntax errors in code that is used if debug is not enabled in libxml,
the gem could not be installed on Linux.
