### PR TITLE
Correct xpath documentation XML

### DIFF
--- a/ext/libxml/ruby_xml_xpath.c
+++ b/ext/libxml/ruby_xml_xpath.c
@@ -50,6 +50,7 @@
  *          <ns1:IdAndName xmlns:ns1="http://domain.somewhere.com"/>
  *        </IDAndNameList>
  *      </getManufacturerNamesResponse>
+ *    </soap:Body>
  *  </soap:Envelope>
  *
  *  # Since the soap namespace is defined on the root


### PR DESCRIPTION
There is an invalid XML snippet at https://xml4r.github.io/libxml-ruby/rdoc/classes/LibXML/XML/XPath.html ; it's missing a /soap:Body tag. This PR fixes the docs.
