### PR TITLE
Use RbConfig instead of Config in extconf.rb.

### DIFF
--- a/ext/libxml/extconf.rb
+++ b/ext/libxml/extconf.rb
@@ -14,7 +14,7 @@ else
   $CFLAGS = CONFIG['CFLAGS']
 end
 $LDFLAGS = CONFIG['LDFLAGS']
-$LIBPATH.push(Config::CONFIG['libdir'])
+$LIBPATH.push(RbConfig::CONFIG['libdir'])
 
 def crash(str)
   printf(" extconf failure: %s\n", str)


### PR DESCRIPTION
`Config` has been deprecated for a while and now is gone from ruby 2.2 so libxml-ruby does not build in ruby 2.2.

`RbConfig` is the advised fix.
