### PR TITLE
Use Process.getrlimit instead of `ulimit` in the tests.

### DIFF
--- a/test/tc_parser.rb
+++ b/test/tc_parser.rb
@@ -14,7 +14,7 @@ class TestParser < Test::Unit::TestCase
     GC.start
     GC.start
   end
-      
+
   # -----  Sources  -------
   def test_document
     file = File.expand_path(File.join(File.dirname(__FILE__), 'model/bands.utf-8.xml'))
@@ -142,7 +142,7 @@ class TestParser < Test::Unit::TestCase
     thread.join
     assert(true)
   end
-  
+
   def test_string
     str = '<ruby_array uga="booga" foo="bar"><fixnum>one</fixnum><fixnum>two</fixnum></ruby_array>'
 
@@ -246,7 +246,7 @@ class TestParser < Test::Unit::TestCase
     max_fd = if RUBY_PLATFORM.match(/mswin32|mingw/i)
       500
     else
-      (`ulimit -n`.chomp.to_i) + 1
+      Process.getrlimit(Process::RLIMIT_NOFILE)[0] + 1
     end
 
     file = File.join(File.dirname(__FILE__), 'model/rubynet.xml')


### PR DESCRIPTION
In modern shells ulimit is a builtin so calling it within backticks can use odd
file not found errors (below). Process.getrlimit should be a safe replacement.

```
  1) Error:
test_fd_gc(TestParser):
Errno::ENOENT: No such file or directory - ulimit -n
    ~/projects/oss/libxml-ruby/test/tc_parser.rb:249:in ``'
    ~/projects/oss/libxml-ruby/test/tc_parser.rb:249:in `test_fd_gc'
```