### PR TITLE
Make libxml-ruby play nice with other consumers

### DIFF
--- a/ext/libxml/ruby_xml.c
+++ b/ext/libxml/ruby_xml.c
@@ -16,7 +16,7 @@ void rxml_owned_del(void *private) {
 }
 
 int rxml_owned_p(void *private) {
-  return st_lookup(owned_pointers, (st_data_t)private, NULL);
+  return private && st_lookup(owned_pointers, (st_data_t)private, NULL);
 }
 
 VALUE mXML;

--- a/ext/libxml/ruby_xml.h
+++ b/ext/libxml/ruby_xml.h
@@ -7,4 +7,18 @@ extern VALUE mXML;
 int rxml_libxml_default_options();
 void rxml_init_xml(void);
 
+void rxml_owned_add(void *private);
+void rxml_owned_del(void *private);
+int rxml_owned_p(void *private);
+
+#define SET_PRIV(obj, private)    rxml_owned_add(obj->_private = (void*)private)
+
+#define CLEAR_PRIV(obj) do {      \
+  if (obj->_private)              \
+    rxml_owned_del(obj->_private);\
+  obj->_private = NULL;           \
+} while (0)
+
+#define OWNED(obj) rxml_owned_p(obj->_private)
+
 #endif

--- a/ext/libxml/ruby_xml_document.c
+++ b/ext/libxml/ruby_xml_document.c
@@ -76,7 +76,7 @@ void rxml_document_mark(xmlDocPtr xdoc)
 
 void rxml_document_free(xmlDocPtr xdoc)
 {
-  xdoc->_private = NULL;
+  CLEAR_PRIV(xdoc);
   xmlFreeDoc(xdoc);
 }
 
@@ -92,7 +92,7 @@ VALUE rxml_document_wrap(xmlDocPtr xdoc)
   else
   {
     result = Data_Wrap_Struct(cXMLDocument, rxml_document_mark, rxml_document_free, xdoc);
-    xdoc->_private = (void*) result;
+    SET_PRIV(xdoc, result);
   }
 
   return result;
@@ -136,7 +136,7 @@ static VALUE rxml_document_initialize(int argc, VALUE *argv, VALUE self)
 
   Check_Type(xmlver, T_STRING);
   xdoc = xmlNewDoc((xmlChar*) StringValuePtr(xmlver));
-  xdoc->_private = (void*) self;
+  SET_PRIV(xdoc, self);
   DATA_PTR(self) = xdoc;
 
   return self;

--- a/ext/libxml/ruby_xml_dtd.c
+++ b/ext/libxml/ruby_xml_dtd.c
@@ -34,7 +34,7 @@ void rxml_dtd_free(xmlDtdPtr xdtd)
 {
   /* Set _private to NULL so that we won't reuse the
    same, freed, Ruby wrapper object later.*/
-  xdtd->_private = NULL;
+  CLEAR_PRIV(xdtd);
 
   if (xdtd->doc == NULL && xdtd->parent == NULL)
     xmlFreeDtd(xdtd);
@@ -69,7 +69,7 @@ VALUE rxml_dtd_wrap(xmlDtdPtr xdtd)
 
   result = Data_Wrap_Struct(cXMLDtd, NULL, NULL, xdtd);
 
-  xdtd->_private = (void*) result;
+  SET_PRIV(xdtd, result);
 
   return result;
 }

--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -45,6 +45,10 @@ static void rxml_node_deregisterNode(xmlNodePtr xnode)
   /* Has the node been wrapped and exposed to Ruby? */
   if (xnode->_private)
   {
+    /* Does it belong to another libxml user? */
+    if (!OWNED(xnode))
+      return;
+
     /* Node was wrapped.  Set the _private member to free and
       then disable the dfree function so that Ruby will not
       try to free the node a second time. */
@@ -52,6 +56,7 @@ static void rxml_node_deregisterNode(xmlNodePtr xnode)
     RDATA(node)->data = NULL;
     RDATA(node)->dfree = NULL;
     RDATA(node)->dmark = NULL;
+    CLEAR_PRIV(xnode);
   }
 }
 
@@ -64,7 +69,7 @@ static void rxml_node_free(xmlNodePtr xnode)
     return;
 
   /* The ruby object wrapping the xml object no longer exists. */
-  xnode->_private = NULL;
+  CLEAR_PRIV(xnode);
 
   /* Ruby is responsible for freeing this node if it does not
      have a parent and is not owned by a document.  Note a corner
@@ -103,7 +108,7 @@ VALUE rxml_node_wrap(xmlNodePtr xnode)
   else
   {
     result = Data_Wrap_Struct(cXMLNode, rxml_node_mark, rxml_node_free, xnode);
-    xnode->_private = (void*) result;
+    SET_PRIV(xnode, result);
   }
   return result;
 }
@@ -276,7 +281,7 @@ static VALUE rxml_node_initialize(int argc, VALUE *argv, VALUE self)
     rxml_raise(&xmlLastError);
 
   /* Link the Ruby object to the libxml object and vice-versa. */
-  xnode->_private = (void*) self;
+  SET_PRIV(xnode, self);
   DATA_PTR(self) = xnode;
 
   if (!NIL_P(content))
@@ -311,7 +316,7 @@ static VALUE rxml_node_modify_dom(VALUE self, VALUE target,
   if (xresult != xtarget)
   {
     RDATA(target)->data = xresult;
-    xresult->_private = (void*) target;
+    SET_PRIV(xresult, target);
   }
 
   return target;
@@ -1146,7 +1151,7 @@ static VALUE rxml_node_remove_ex(VALUE self)
   xresult = xmlDocCopyNode(xnode, NULL, 1);
 
   /* This ruby node object no longer points at the node.*/
-  xnode->_private = NULL;
+  CLEAR_PRIV(xnode);
   RDATA(self)->data = NULL;
 
   /* Now free the original node.  This will call the deregister node
@@ -1156,7 +1161,7 @@ static VALUE rxml_node_remove_ex(VALUE self)
 
   /* Now wrap the new node */
   RDATA(self)->data = xresult;
-  xresult->_private = (void*) self;
+  SET_PRIV(xresult, self);
 
   /* Now return the removed node so the user can
      do something with it.*/

--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -42,22 +42,18 @@ VALUE cXMLNode;
 
 static void rxml_node_deregisterNode(xmlNodePtr xnode)
 {
-  /* Has the node been wrapped and exposed to Ruby? */
-  if (xnode->_private)
-  {
-    /* Does it belong to another libxml user? */
-    if (!OWNED(xnode))
-      return;
+  /* Does it belong to another libxml user? */
+  if (!OWNED(xnode))
+    return;
 
-    /* Node was wrapped.  Set the _private member to free and
-      then disable the dfree function so that Ruby will not
-      try to free the node a second time. */
-    VALUE node = (VALUE) xnode->_private;
-    RDATA(node)->data = NULL;
-    RDATA(node)->dfree = NULL;
-    RDATA(node)->dmark = NULL;
-    CLEAR_PRIV(xnode);
-  }
+  /* Node was wrapped.  Set the _private member to free and
+    then disable the dfree function so that Ruby will not
+    try to free the node a second time. */
+  VALUE node = (VALUE) xnode->_private;
+  RDATA(node)->data = NULL;
+  RDATA(node)->dfree = NULL;
+  RDATA(node)->dmark = NULL;
+  CLEAR_PRIV(xnode);
 }
 
 static void rxml_node_free(xmlNodePtr xnode)


### PR DESCRIPTION
`libxml-ruby` registers a global callback with libxml for node
deletions. If a node's `_private` field is not NULL, `libxml-ruby`
reaches through the pointer and clobbers a few fields. This interacts
badly with other consumers of the underlying libxml library, such as
Nokogiri. This fixes the behaviour by maintaining a hashtable of node
pointers which we own and not allowing writing through any others.

We have been running this in production for close to 48 hours and so far
it's stopped all occurrences of segmentation faults where previously we
would be receiving ~25 per hour. We've been monitoring for memory leaks
but have not yet seen anything.
