### PR TITLE
Store libxml -> Ruby object mappings in a hashtable

### DIFF
--- a/ext/libxml/ruby_xml.h
+++ b/ext/libxml/ruby_xml.h
@@ -7,4 +7,9 @@ extern VALUE mXML;
 int rxml_libxml_default_options();
 void rxml_init_xml(void);
 
+void rxml_private_set(void *node, VALUE private);
+void rxml_private_del(void *node);
+VALUE rxml_private_get(void *node);
+void rxml_private_mark(void *node);
+
 #endif

--- a/ext/libxml/ruby_xml_attr.c
+++ b/ext/libxml/ruby_xml_attr.c
@@ -19,13 +19,13 @@
 /* Attributes are owned and freed by their nodes.  Thus, its easier for the
    ruby bindings to not manage attribute memory management.  This does mean
    that accessing a particular attribute multiple times will return multiple
-   different ruby objects.  Since we are not using free or xnode->_private
-   this works out fine.  Previous versions of the bindings had a one to
-   one mapping between ruby object and xml attribute, but that could 
-   result in segfaults because the ruby object could be gc'ed.  In theory
-   the mark method on the parent node could prevent that, but if an 
-   attribute is returned using an xpath statement then the node would
-   never by surfaced to ruby and the mark method never called. */
+   different ruby objects.  Since we are not using free this works out fine.
+   Previous versions of the bindings had a one to one mapping between ruby
+   object and xml attribute, but that could result in segfaults because the
+   ruby object could be gc'ed.  In theory the mark method on the parent node
+   could prevent that, but if an attribute is returned using an xpath statement
+   then the node would never by surfaced to ruby and the mark method never
+   called. */
 
 #include "ruby_libxml.h"
 #include "ruby_xml_attr.h"

--- a/ext/libxml/ruby_xml_dtd.c
+++ b/ext/libxml/ruby_xml_dtd.c
@@ -32,9 +32,9 @@ VALUE cXMLDtd;
 
 void rxml_dtd_free(xmlDtdPtr xdtd)
 {
-  /* Set _private to NULL so that we won't reuse the
+  /* Clear our private pointer so that we won't reuse the
    same, freed, Ruby wrapper object later.*/
-  xdtd->_private = NULL;
+  rxml_private_del(xdtd);
 
   if (xdtd->doc == NULL && xdtd->parent == NULL)
     xmlFreeDtd(xdtd);
@@ -45,10 +45,8 @@ void rxml_dtd_mark(xmlDtdPtr xdtd)
   if (xdtd == NULL)
     return;
 
-  if (xdtd->_private == NULL)
-  {
-    return;
-  }
+  if (rxml_private_get(xdtd) == 0)
+      return;
 
   rxml_node_mark((xmlNodePtr) xdtd);
 }
@@ -61,16 +59,14 @@ static VALUE rxml_dtd_alloc(VALUE klass)
 
 VALUE rxml_dtd_wrap(xmlDtdPtr xdtd)
 {
-  VALUE result;
+  VALUE result = rxml_private_get(xdtd);
 
   // This node is already wrapped
-  if (xdtd->_private != NULL)
-    return (VALUE) xdtd->_private;
+  if (result)
+      return result;
 
   result = Data_Wrap_Struct(cXMLDtd, NULL, NULL, xdtd);
-
-  xdtd->_private = (void*) result;
-
+  rxml_private_set(xdtd, result);
   return result;
 }
 

--- a/ext/libxml/ruby_xml_reader.c
+++ b/ext/libxml/ruby_xml_reader.c
@@ -62,9 +62,7 @@ static void rxml_reader_free(xmlTextReaderPtr xreader)
 static void rxml_reader_mark(xmlTextReaderPtr xreader)
 {
   xmlDocPtr xdoc = xmlTextReaderCurrentDoc(xreader);
-
-  if (xdoc && xdoc->_private)
-    rb_gc_mark((VALUE) xdoc->_private);
+  rxml_private_mark(xdoc);
 }
 
 static VALUE rxml_reader_wrap(xmlTextReaderPtr xreader)

--- a/ext/libxml/ruby_xml_xpath_context.c
+++ b/ext/libxml/ruby_xml_xpath_context.c
@@ -33,8 +33,7 @@ static void rxml_xpath_context_free(xmlXPathContextPtr ctxt)
 
 static void rxml_xpath_context_mark(xmlXPathContextPtr ctxt)
 {
-  if (ctxt && ctxt->doc->_private)
-    rb_gc_mark((VALUE) ctxt->doc->_private);
+  rxml_private_mark(ctxt);
 }
 
 static VALUE rxml_xpath_context_alloc(VALUE klass)

--- a/ext/libxml/ruby_xml_xpath_object.c
+++ b/ext/libxml/ruby_xml_xpath_object.c
@@ -51,8 +51,7 @@ static void rxml_xpath_namespace_free(xmlNsPtr xns)
 static void rxml_xpath_object_mark(rxml_xpath_object *rxpop)
 {
   rb_gc_mark(rxpop->nsnodes);
-  if (rxpop->xdoc->_private)
-    rb_gc_mark((VALUE)rxpop->xdoc->_private);
+  rxml_private_mark(rxpop->xdoc);
 }
 
 VALUE rxml_xpath_object_wrap(xmlDocPtr xdoc, xmlXPathObjectPtr xpop)


### PR DESCRIPTION
Maintain a hashtable of mappings from libxml objects to Ruby objects by
address. This replaces the mechanism of using the _private pointer in
the libxml objects.

This supersedes #118, with changes as discussed.