### PR TITLE
force external encoding to UTF-8 for tests

### DIFF
--- a/test/test_suite.rb
+++ b/test/test_suite.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+Encoding.default_external="UTF-8"
 
 # Change to current directory so relative
 # requires work.


### PR DESCRIPTION
This is needed to make the test suite succeed in environment where UTF-8 is not the default (like Debian package building machines)