### PR TITLE
Remove assert_equal(nil, ...) in favor of assert_nil(...)

### DIFF
--- a/test/tc_namespace.rb
+++ b/test/tc_namespace.rb
@@ -23,7 +23,7 @@ class TestNS < Minitest::Test
   def test_create_default_ns
     node = XML::Node.new('foo')
     ns = XML::Namespace.new(node, nil, 'http://www.mynamespace.com')
-    assert_equal(ns.prefix, nil)
+    assert_nil(ns.prefix)
     assert_equal(ns.href, 'http://www.mynamespace.com')
   end
 

--- a/test/tc_namespaces.rb
+++ b/test/tc_namespaces.rb
@@ -157,7 +157,7 @@ class TestNamespaces < Minitest::Test
 
     namespace = ns_defs[0]
     assert_instance_of(XML::Namespace, namespace)
-    assert_equal(nil, namespace.prefix)
+    assert_nil(namespace.prefix)
     assert_equal('http://services.somewhere.com', namespace.href)
   end
 
@@ -178,7 +178,7 @@ class TestNamespaces < Minitest::Test
     namespace = node.namespaces.find_by_prefix(nil)
 
     assert_instance_of(XML::Namespace, namespace)
-    assert_equal(nil, namespace.prefix)
+    assert_nil(namespace.prefix)
     assert_equal('http://services.somewhere.com', namespace.href)
   end
 

--- a/test/tc_parser_context.rb
+++ b/test/tc_parser_context.rb
@@ -171,7 +171,7 @@ class TestParserContext < Minitest::Test
 
     # Now check context
     context = xp.context
-    assert_equal(nil, context.data_directory)
+    assert_nil(context.data_directory)
     assert_equal(0, context.depth)
     assert_equal(true, context.disable_sax?)
     assert_equal(false, context.docbook?)
@@ -182,7 +182,7 @@ class TestParserContext < Minitest::Test
     assert_equal(1, context.io_num_streams)
     assert_equal(true, context.keep_blanks?)
     assert_equal(1, context.io_num_streams)
-    assert_equal(nil, context.name_node)
+    assert_nil(context.name_node)
     assert_equal(0, context.name_depth)
     assert_equal(10, context.name_depth_max)
     assert_equal(17, context.num_chars)
@@ -190,10 +190,10 @@ class TestParserContext < Minitest::Test
     assert_equal(1, context.space_depth)
     assert_equal(10, context.space_depth_max)
     assert_equal(false, context.subset_external?)
-    assert_equal(nil, context.subset_external_system_id)
-    assert_equal(nil, context.subset_external_uri)
+    assert_nil(context.subset_external_system_id)
+    assert_nil(context.subset_external_uri)
     assert_equal(false, context.subset_internal?)
-    assert_equal(nil, context.subset_internal_name)
+    assert_nil(context.subset_internal_name)
     assert_equal(false, context.stats?)
     assert_equal(true, context.standalone?)
     assert_equal(false, context.valid)

--- a/test/tc_reader.rb
+++ b/test/tc_reader.rb
@@ -142,16 +142,16 @@ class TestReader < Minitest::Test
       assert_equal(reader.get_attribute_ns('id', 'http://www.w3.org/XML/1998/namespace'), 'abc')
       assert_equal(reader.get_attribute('bar'), 'jkl')
 
-      assert_equal(reader.get_attribute_no(12), nil)
-      assert_equal(reader.get_attribute('baz'), nil)
-      assert_equal(reader.get_attribute_ns('baz', 'http://ruby/namespace'), nil)
+      assert_nil(reader.get_attribute_no(12))
+      assert_nil(reader.get_attribute('baz'))
+      assert_nil(reader.get_attribute_ns('baz', 'http://ruby/namespace'))
   end
 
   def test_value
     parser = XML::Reader.string("<foo><bar>1</bar><bar>2</bar><bar>3</bar></foo>")
     assert(parser.read)
     assert_equal('foo', parser.name)
-    assert_equal(nil, parser.value)
+    assert_nil(parser.value)
     3.times do |i|
       assert(parser.read)
       assert_equal(XML::Reader::TYPE_ELEMENT, parser.node_type)

--- a/test/tc_schema.rb
+++ b/test/tc_schema.rb
@@ -107,7 +107,7 @@ class TestSchema < Minitest::Test
     type = schema.types['shiporder']
 
     assert_equal('shiporder', type.name)
-    assert_equal(nil, type.namespace)
+    assert_nil(type.namespace)
     assert_equal("Shiporder type documentation", type.annotation)
     assert_instance_of(XML::Node, type.node)
     assert_equal(XML::Schema::Types::XML_SCHEMA_TYPE_COMPLEX, type.kind)
@@ -123,7 +123,7 @@ class TestSchema < Minitest::Test
     element = schema.types['shiporder'].elements['orderperson']
 
     assert_equal('orderperson', element.name)
-    assert_equal(nil, element.namespace)
+    assert_nil(element.namespace)
     assert_equal("orderperson element documentation", element.annotation)
     assert_equal(1, element.min_occurs)
     assert_equal(1, element.max_occurs)
@@ -149,7 +149,7 @@ class TestSchema < Minitest::Test
     attribute = schema.types['shiporder'].attributes.first
 
     assert_equal("orderid", attribute.name)
-    assert_equal(nil, attribute.namespace)
+    assert_nil(attribute.namespace)
     assert_equal(1, attribute.occurs)
     assert_equal('string', attribute.type.name)
 


### PR DESCRIPTION
Remove all the depreciation warnings:

e.g.

```ruby
DEPRECATED: Use assert_nil if expecting nil from [...]. This will fail in Minitest 6.
```