### PR TITLE
Avoid gem build failure:

### DIFF
--- a/libxml-ruby.gemspec
+++ b/libxml-ruby.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'date'
 
 # Determine the current version of the software
 version = File.read('ext/libxml/ruby_xml_version.h').match(/\s*RUBY_LIBXML_VERSION\s*['"](\d.+)['"]/)[1]


### PR DESCRIPTION
```
$ gem build libxml-ruby.gemspec
Invalid gemspec in [libxml-ruby.gemspec]: uninitialized constant Gem::Specification::DateTime
Did you mean?  Gem::Specification::DateLike
ERROR:  Error loading gemspec. Aborting.
```