### PR TITLE
Replaced deprecated `assert_euqal(nil, expected)`

### DIFF
--- a/ext/libxml/ruby_xml_reader.c
+++ b/ext/libxml/ruby_xml_reader.c
@@ -23,7 +23,7 @@
  *  reader = XML::Reader.string("<foo><bar>1</bar><bar>2</bar><bar>3</bar></foo>")
  *  reader.read
  *  assert_equal('foo', reader.name)
- *  assert_equal(nil, reader.value)
+ *  assert_nil(reader.value)
  *
  *  3.times do |i|
  *    reader.read

--- a/test/tc_namespaces.rb
+++ b/test/tc_namespaces.rb
@@ -98,7 +98,7 @@ class TestNamespaces < Minitest::Test
 
     namespace = namespaces[0]
     assert_instance_of(XML::Namespace, namespace)
-    assert_equal(nil, namespace.prefix)
+    assert_nil(namespace.prefix)
     assert_equal('http://services.somewhere.com', namespace.href)
 
     namespace = namespaces[1]


### PR DESCRIPTION
This will fail in Minitest 6