### PR TITLE
Fix memory leak in `rxml_node_path` funcion (node.path method)

### DIFF
--- a/ext/libxml/ruby_xml_node.c
+++ b/ext/libxml/ruby_xml_node.c
@@ -983,14 +983,18 @@ static VALUE rxml_node_path(VALUE self)
 {
   xmlNodePtr xnode;
   xmlChar *path;
+  VALUE result = Qnil;
 
   xnode = rxml_get_xnode(self);
   path = xmlGetNodePath(xnode);
 
-  if (path == NULL)
-    return (Qnil);
-  else
-    return (rxml_new_cstr( path, NULL));
+  if (path)
+  {
+    result = rxml_new_cstr( path, NULL);
+    xmlFree(path);
+  }
+
+  return result;
 }
 
 /*


### PR DESCRIPTION
This patch fixes a memory leak in `node.path` method.

Demo:

```ruby
def test_path_memory
 node = LibXML::XML::Node.new('node')
 p `ps -o rss= -p #{Process.pid}`.to_f
 1000000.times do
   node.path
 end
 p `ps -o rss= -p #{Process.pid}`.to_f
end
```