### PR TITLE
Add schema.imported_elements so we can find those imported elements

### DIFF
--- a/ext/libxml/ruby_xml_namespace.c
+++ b/ext/libxml/ruby_xml_namespace.c
@@ -52,6 +52,7 @@ static VALUE rxml_namespace_initialize(VALUE self, VALUE node, VALUE prefix,
 
   Check_Type(node, T_DATA);
   Data_Get_Struct(node, xmlNode, xnode);
+  xmlResetLastError();
 
   /* Prefix can be null - that means its the default namespace */
   xmlPrefix = NIL_P(prefix) ? NULL : (xmlChar *)StringValuePtr(prefix);

--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -234,8 +234,8 @@ static void collect_imported_ns_elements(xmlSchemaImportPtr import, VALUE result
 {
   if (import->imported && import->schema)
   {
-    const char *tns;
     VALUE elements = rb_hash_new();
+    VALUE tns;
     xmlHashScan(import->schema->elemDecl, (xmlHashScanner)scan_schema_element, (void *)elements);
     tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
     rb_hash_aset(result, tns, elements);
@@ -317,8 +317,8 @@ static void collect_imported_ns_types(xmlSchemaImportPtr import, VALUE result, c
 {
   if (import->imported && import->schema)
   {
-    const char *tns;
     VALUE types = rb_hash_new();
+    VALUE tns;
     xmlHashScan(import->schema->typeDecl, (xmlHashScanner)scan_schema_type, (void *)types);
     tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
     rb_hash_aset(result, tns, types);

--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -209,6 +209,29 @@ static VALUE rxml_schema_elements(VALUE self)
   return result;
 }
 
+static void collect_imported_elements(xmlSchemaImportPtr import, VALUE result)
+{
+  if (import->imported && import->schema)
+  {
+    xmlHashScan(import->schema->elemDecl, (xmlHashScanner)scan_element, (void *)result);
+  }
+}
+
+static VALUE rxml_schema_imported_elements(VALUE self)
+{
+  xmlSchemaPtr xschema;
+  VALUE result = rb_hash_new();
+
+  Data_Get_Struct(self, xmlSchema, xschema);
+
+  if (xschema)
+  {
+	  xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_elements, (void *)result);
+  }
+
+  return result;
+}
+
 static void scan_type(xmlSchemaTypePtr xtype, VALUE hash, xmlChar *name)
 {
 	VALUE type = rxml_wrap_schema_type(xtype);
@@ -266,10 +289,11 @@ void rxml_init_schema(void)
   rb_define_method(cXMLSchema, "version", rxml_schema_version, 0);
   rb_define_method(cXMLSchema, "document", rxml_schema_document, 0);
 
-  rb_define_method(cXMLSchema, "elements", rxml_schema_elements, 0);
-  rb_define_method(cXMLSchema, "imported_types", rxml_schema_imported_types, 0);
   rb_define_method(cXMLSchema, "namespaces", rxml_schema_namespaces, 0);
+  rb_define_method(cXMLSchema, "elements", rxml_schema_elements, 0);
+  rb_define_method(cXMLSchema, "imported_elements", rxml_schema_imported_elements, 0);
   rb_define_method(cXMLSchema, "types", rxml_schema_types, 0);
+  rb_define_method(cXMLSchema, "imported_types", rxml_schema_imported_types, 0);
 
   rxml_init_schema_facet();
   rxml_init_schema_element();

--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -49,6 +49,18 @@ VALUE rxml_wrap_schema(xmlSchemaPtr xschema)
   return Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
 }
 
+static VALUE rxml_schema_init(VALUE class, xmlSchemaParserCtxtPtr xparser)
+{
+  xmlSchemaPtr xschema;
+
+  xschema = xmlSchemaParse(xparser);
+  xmlSchemaFreeParserCtxt(xparser);
+
+  if (!xschema)
+    rxml_raise(&xmlLastError);
+
+  return rxml_wrap_schema(xschema);
+}
 
 /*
  * call-seq:
@@ -59,15 +71,14 @@ VALUE rxml_wrap_schema(xmlSchemaPtr xschema)
 static VALUE rxml_schema_init_from_uri(VALUE class, VALUE uri)
 {
   xmlSchemaParserCtxtPtr xparser;
-  xmlSchemaPtr xschema;
 
   Check_Type(uri, T_STRING);
 
   xparser = xmlSchemaNewParserCtxt(StringValuePtr(uri));
-  xschema = xmlSchemaParse(xparser);
-  xmlSchemaFreeParserCtxt(xparser);
+  if (!xparser)
+    rxml_raise(&xmlLastError);
 
-  return Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+  return rxml_schema_init(class, xparser);
 }
 
 /*
@@ -79,19 +90,15 @@ static VALUE rxml_schema_init_from_uri(VALUE class, VALUE uri)
 static VALUE rxml_schema_init_from_document(VALUE class, VALUE document)
 {
   xmlDocPtr xdoc;
-  xmlSchemaPtr xschema;
   xmlSchemaParserCtxtPtr xparser;
 
   Data_Get_Struct(document, xmlDoc, xdoc);
 
   xparser = xmlSchemaNewDocParserCtxt(xdoc);
-  xschema = xmlSchemaParse(xparser);
-  xmlSchemaFreeParserCtxt(xparser);
+  if (!xparser)
+    rxml_raise(&xmlLastError);
 
-  if (xschema == NULL)
-    return Qnil;
-
-  return Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+  return rxml_schema_init(class, xparser);
 }
 
 /*
@@ -100,20 +107,18 @@ static VALUE rxml_schema_init_from_document(VALUE class, VALUE document)
  *
  * Create a new schema using the specified string.
  */
-static VALUE rxml_schema_init_from_string(VALUE self, VALUE schema_str)
+static VALUE rxml_schema_init_from_string(VALUE class, VALUE schema_str)
 {
   xmlSchemaParserCtxtPtr xparser;
-  xmlSchemaPtr xschema;
 
   Check_Type(schema_str, T_STRING);
 
   xparser = xmlSchemaNewMemParserCtxt(StringValuePtr(schema_str), (int)strlen(StringValuePtr(schema_str)));
-  xschema = xmlSchemaParse(xparser);
-  xmlSchemaFreeParserCtxt(xparser);
+  if (!xparser)
+    rxml_raise(&xmlLastError);
 
-  return Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+  return rxml_schema_init(class, xparser);
 }
-
 
 static VALUE rxml_schema_target_namespace(VALUE self)
 {
@@ -151,6 +156,13 @@ static VALUE rxml_schema_id(VALUE self)
   QNIL_OR_STRING(xschema->id)
 }
 
+
+/*
+ * call-seq:
+ *    XML::Schema.document -> document
+ *
+ * Return the Schema XML Document
+ */
 static VALUE rxml_schema_document(VALUE self)
 {
   xmlSchemaPtr xschema;
@@ -160,7 +172,7 @@ static VALUE rxml_schema_document(VALUE self)
   return rxml_node_wrap(xmlDocGetRootElement(xschema->doc));
 }
 
-static void scan_namespaces(xmlSchemaImportPtr ximport, VALUE array, xmlChar *nsname)
+static void scan_namespaces(xmlSchemaImportPtr ximport, VALUE array, const xmlChar *nsname)
 {
   xmlNodePtr xnode;
   xmlNsPtr xns;
@@ -171,7 +183,7 @@ static void scan_namespaces(xmlSchemaImportPtr ximport, VALUE array, xmlChar *ns
     xns = xnode->nsDef;
 
     while (xns)
-	{
+    {
       VALUE namespace = rxml_namespace_wrap(xns);
       rb_ary_push(array, namespace);
       xns = xns->next;
@@ -179,6 +191,12 @@ static void scan_namespaces(xmlSchemaImportPtr ximport, VALUE array, xmlChar *ns
   }
 }
 
+/*
+ * call-seq:
+ *    XML::Schema.namespaces -> array
+ *
+ * Returns an array of Namespaces defined by the schema
+ */
 static VALUE rxml_schema_namespaces(VALUE self)
 {
   VALUE result;
@@ -192,7 +210,7 @@ static VALUE rxml_schema_namespaces(VALUE self)
   return result;
 }
 
-static void scan_element(xmlSchemaElementPtr xelement, VALUE hash, xmlChar *name)
+static void scan_schema_element(xmlSchemaElementPtr xelement, VALUE hash, const xmlChar *name)
 {
   VALUE element = rxml_wrap_schema_element(xelement);
   rb_hash_aset(hash, rb_str_new2((const char*)name), element);
@@ -204,20 +222,30 @@ static VALUE rxml_schema_elements(VALUE self)
   xmlSchemaPtr xschema;
 
   Data_Get_Struct(self, xmlSchema, xschema);
-  xmlHashScan(xschema->elemDecl, (xmlHashScanner)scan_element, (void *)result);
+  xmlHashScan(xschema->elemDecl, (xmlHashScanner)scan_schema_element, (void *)result);
 
   return result;
 }
 
-static void collect_imported_elements(xmlSchemaImportPtr import, VALUE result)
+static void collect_imported_ns_elements(xmlSchemaImportPtr import, VALUE result, const xmlChar *name)
 {
   if (import->imported && import->schema)
   {
-    xmlHashScan(import->schema->elemDecl, (xmlHashScanner)scan_element, (void *)result);
+    const char *tns;
+    VALUE elements = rb_hash_new();
+    xmlHashScan(import->schema->elemDecl, (xmlHashScanner)scan_schema_element, (void *)elements);
+    tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
+    rb_hash_aset(result, tns, elements);
   }
 }
 
-static VALUE rxml_schema_imported_elements(VALUE self)
+/*
+ * call-seq:
+ *    XML::Schema.imported_ns_elements -> hash
+ *
+ * Returns a hash by namespace of a hash of schema elements within the entire schema including imports
+ */
+static VALUE rxml_schema_imported_ns_elements(VALUE self)
 {
   xmlSchemaPtr xschema;
   VALUE result = rb_hash_new();
@@ -226,41 +254,47 @@ static VALUE rxml_schema_imported_elements(VALUE self)
 
   if (xschema)
   {
-	  xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_elements, (void *)result);
+    xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_ns_elements, (void *)result);
   }
 
   return result;
 }
 
-static void scan_type(xmlSchemaTypePtr xtype, VALUE hash, xmlChar *name)
+static void scan_schema_type(xmlSchemaTypePtr xtype, VALUE hash, const xmlChar *name)
 {
-	VALUE type = rxml_wrap_schema_type(xtype);
-	rb_hash_aset(hash, rb_str_new2((const char*)name), type);
+  VALUE type = rxml_wrap_schema_type(xtype);
+  rb_hash_aset(hash, rb_str_new2((const char*)name), type);
 }
 
 static VALUE rxml_schema_types(VALUE self)
 {
-	VALUE result = rb_hash_new();
-	xmlSchemaPtr xschema;
+  VALUE result = rb_hash_new();
+  xmlSchemaPtr xschema;
 
-	Data_Get_Struct(self, xmlSchema, xschema);
+  Data_Get_Struct(self, xmlSchema, xschema);
 
-	if (xschema != NULL && xschema->typeDecl != NULL)
-	{
-		xmlHashScan(xschema->typeDecl, (xmlHashScanner)scan_type, (void *)result);
-	}
+  if (xschema != NULL && xschema->typeDecl != NULL)
+  {
+    xmlHashScan(xschema->typeDecl, (xmlHashScanner)scan_schema_type, (void *)result);
+  }
 
-	return result;
+  return result;
 }
 
-static void collect_imported_types(xmlSchemaImportPtr import, VALUE result)
+static void collect_imported_types(xmlSchemaImportPtr import, VALUE result, const xmlChar *name)
 {
   if (import->imported && import->schema)
   {
-    xmlHashScan(import->schema->typeDecl, (xmlHashScanner)scan_type, (void *)result);
+    xmlHashScan(import->schema->typeDecl, (xmlHashScanner)scan_schema_type, (void *)result);
   }
 }
 
+/*
+ * call-seq:
+ *    XML::Schema.imported_types -> hash
+ *
+ * Returns a hash of all types within the entire schema including imports
+ */
 static VALUE rxml_schema_imported_types(VALUE self)
 {
   xmlSchemaPtr xschema;
@@ -270,7 +304,40 @@ static VALUE rxml_schema_imported_types(VALUE self)
 
   if (xschema)
   {
-	  xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_types, (void *)result);
+    xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_types, (void *)result);
+  }
+
+  return result;
+}
+
+static void collect_imported_ns_types(xmlSchemaImportPtr import, VALUE result, const xmlChar *name)
+{
+  if (import->imported && import->schema)
+  {
+    const char *tns;
+    VALUE types = rb_hash_new();
+    xmlHashScan(import->schema->typeDecl, (xmlHashScanner)scan_schema_type, (void *)types);
+    tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
+    rb_hash_aset(result, tns, types);
+  }
+}
+
+/*
+ * call-seq:
+ *    XML::Schema.imported_ns_types -> hash
+ *
+ * Returns a hash by namespace of a hash of schema types within the entire schema including imports
+ */
+static VALUE rxml_schema_imported_ns_types(VALUE self)
+{
+  xmlSchemaPtr xschema;
+  VALUE result = rb_hash_new();
+
+  Data_Get_Struct(self, xmlSchema, xschema);
+
+  if (xschema)
+  {
+    xmlHashScan(xschema->schemasImports, (xmlHashScanner)collect_imported_ns_types, (void *)result);
   }
 
   return result;
@@ -288,12 +355,12 @@ void rxml_init_schema(void)
   rb_define_method(cXMLSchema, "id", rxml_schema_id, 0);
   rb_define_method(cXMLSchema, "version", rxml_schema_version, 0);
   rb_define_method(cXMLSchema, "document", rxml_schema_document, 0);
-
   rb_define_method(cXMLSchema, "namespaces", rxml_schema_namespaces, 0);
   rb_define_method(cXMLSchema, "elements", rxml_schema_elements, 0);
-  rb_define_method(cXMLSchema, "imported_elements", rxml_schema_imported_elements, 0);
+  rb_define_method(cXMLSchema, "imported_ns_elements", rxml_schema_imported_ns_elements, 0);
   rb_define_method(cXMLSchema, "types", rxml_schema_types, 0);
   rb_define_method(cXMLSchema, "imported_types", rxml_schema_imported_types, 0);
+  rb_define_method(cXMLSchema, "imported_ns_types", rxml_schema_imported_ns_types, 0);
 
   rxml_init_schema_facet();
   rxml_init_schema_element();

--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -74,6 +74,7 @@ static VALUE rxml_schema_init_from_uri(VALUE class, VALUE uri)
 
   Check_Type(uri, T_STRING);
 
+  xmlResetLastError();
   xparser = xmlSchemaNewParserCtxt(StringValuePtr(uri));
   if (!xparser)
     rxml_raise(&xmlLastError);
@@ -94,6 +95,7 @@ static VALUE rxml_schema_init_from_document(VALUE class, VALUE document)
 
   Data_Get_Struct(document, xmlDoc, xdoc);
 
+  xmlResetLastError();
   xparser = xmlSchemaNewDocParserCtxt(xdoc);
   if (!xparser)
     rxml_raise(&xmlLastError);
@@ -113,6 +115,7 @@ static VALUE rxml_schema_init_from_string(VALUE class, VALUE schema_str)
 
   Check_Type(schema_str, T_STRING);
 
+  xmlResetLastError();
   xparser = xmlSchemaNewMemParserCtxt(StringValuePtr(schema_str), (int)strlen(StringValuePtr(schema_str)));
   if (!xparser)
     rxml_raise(&xmlLastError);

--- a/ext/libxml/ruby_xml_version.h
+++ b/ext/libxml/ruby_xml_version.h
@@ -1,7 +1,7 @@
 /* Don't nuke this block!  It is used for automatically updating the
  * versions below. VERSION = string formatting, VERNUM = numbered
  * version for inline testing: increment both or none at all.*/
-#define RUBY_LIBXML_VERSION  "3.2.2"
+#define RUBY_LIBXML_VERSION  "3.2.3-dev"
 #define RUBY_LIBXML_VERNUM   321
 #define RUBY_LIBXML_VER_MAJ   3
 #define RUBY_LIBXML_VER_MIN   2

--- a/ext/libxml/ruby_xml_version.h
+++ b/ext/libxml/ruby_xml_version.h
@@ -2,8 +2,8 @@
  * versions below. VERSION = string formatting, VERNUM = numbered
  * version for inline testing: increment both or none at all.*/
 #define RUBY_LIBXML_VERSION  "3.2.3-dev"
-#define RUBY_LIBXML_VERNUM   321
+#define RUBY_LIBXML_VERNUM   323
 #define RUBY_LIBXML_VER_MAJ   3
 #define RUBY_LIBXML_VER_MIN   2
-#define RUBY_LIBXML_VER_MIC   2
+#define RUBY_LIBXML_VER_MIC   3
 #define RUBY_LIBXML_VER_PATCH 0

--- a/test/model/shiporder.rnc
+++ b/test/model/shiporder.rnc
@@ -5,9 +5,9 @@
 #
 namespace xsi = "http://www.w3.org/2001/XMLSchema-instance"
 
-start = shiporder
+start = shiporderType
 
-shiporder  = element shiporder { attribute orderid { text }, 
+shiporderType  = element shiporder { attribute orderid { text },
                                  attribute xsi:noNamespaceSchemaLocation { text }, 
                                orderperson, shipto, item* }
 

--- a/test/model/shiporder.rng
+++ b/test/model/shiporder.rng
@@ -7,9 +7,9 @@
 -->
 <grammar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
-    <ref name="shiporder"/>
+    <ref name="shiporderType"/>
   </start>
-  <define name="shiporder">
+  <define name="shiporderType">
     <element name="shiporder">
       <attribute name="orderid"/>
       <attribute name="xsi:noNamespaceSchemaLocation"/>

--- a/test/model/shiporder.xsd
+++ b/test/model/shiporder.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="shiporder" type="shiporder"/>
+  <xs:element name="shiporder" type="shiporderType"/>
 
-  <xs:complexType name="shiporder">
+  <xs:complexType name="shiporderType">
     <xs:annotation>
       <xs:documentation>Shiporder type documentation</xs:documentation>
     </xs:annotation>

--- a/test/model/shiporder_bad.xsd
+++ b/test/model/shiporder_bad.xsd
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-  <xs:import namespace="http://xml4r.org/ibxml-ruby/test/shiporder"
-             schemaLocation="shiporder_import.xsd"/>
-
   <xs:element name="shiporder" type="shiporderType"/>
 
   <xs:complexType name="shiporderType">
-    <xs:annotation>
+    <xs:anntation>
       <xs:documentation>Shiporder type documentation</xs:documentation>
-    </xs:annotation>
+    </xs:anntation>
     <xs:sequence>
       <xs:element name="orderperson" type="xs:string">
         <xs:annotation>
@@ -28,12 +24,12 @@
       </xs:element>
       <xs:element name="item" maxOccurs="unbounded">
         <xs:complexType>
-          <xs:sequence>
+          <xs:seq>
             <xs:element name="title" type="xs:string"/>
             <xs:element name="note" type="xs:string" minOccurs="0"/>
             <xs:element name="quantity" type="xs:positiveInteger"/>
             <xs:element name="price" type="xs:decimal"/>
-          </xs:sequence>
+          </xs:seq>
         </xs:complexType>
       </xs:element>
     </xs:sequence>

--- a/test/model/shiporder_import.xsd
+++ b/test/model/shiporder_import.xsd
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="iso-8859-1" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns="http://xml4r.org/libxml-ruby/test/shiporder"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://xml4r.org/libxml-ruby/test/shiporder">
 
-  <xs:import namespace="http://xml4r.org/ibxml-ruby/test/shiporder"
-             schemaLocation="shiporder_import.xsd"/>
-
-  <xs:element name="shiporder" type="shiporderType"/>
-
-  <xs:complexType name="shiporderType">
+  <xs:element name="shiporder" type="shiporderFooType"/>
+  <xs:complexType name="shiporderFooType">
     <xs:annotation>
-      <xs:documentation>Shiporder type documentation</xs:documentation>
+      <xs:documentation>Shiporder type documentation for Testing of imported schema</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="orderperson" type="xs:string">
@@ -23,6 +21,7 @@
             <xs:element name="address" type="xs:string"/>
             <xs:element name="city" type="xs:string"/>
             <xs:element name="country" type="xs:string"/>
+            <xs:element name="phone" type="xs:string"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -33,12 +32,14 @@
             <xs:element name="note" type="xs:string" minOccurs="0"/>
             <xs:element name="quantity" type="xs:positiveInteger"/>
             <xs:element name="price" type="xs:decimal"/>
+            <xs:element name="discount" type="xs:decimal"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
     <xs:attribute name="orderid" type="xs:string" use="required"/>
     <xs:attribute name="foo" default="1" type="xs:integer" use="optional"/>
-    <xs:attribute name="bar" use="prohibited"/>
+    <xs:attribute name="bar" type="xs:string" use="optional"/>
+    <xs:attribute name="xyzzy" type="xs:string" use="prohibited"/>
   </xs:complexType>
 </xs:schema>

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -99,13 +99,19 @@ class TestSchema < Minitest::Test
   def test_types
     assert_instance_of(Hash, schema.types)
     assert_equal(1, schema.types.length)
-    assert_instance_of(LibXML::XML::Schema::Type, schema.types['shiporder'])
+    assert_instance_of(LibXML::XML::Schema::Type, schema.types['shiporderType'])
   end
 
   def test_imported_types
     assert_instance_of(Hash, schema.imported_types)
     assert_equal(1, schema.imported_types.length)
-    assert_instance_of(LibXML::XML::Schema::Type, schema.types['shiporder'])
+    assert_instance_of(LibXML::XML::Schema::Type, schema.imported_types['shiporderType'])
+  end
+
+  def test_imported_elements
+    assert_instance_of(Hash, schema.imported_elements)
+    assert_equal(1, schema.imported_elements.length)
+    assert_instance_of(LibXML::XML::Schema::Element, schema.imported_elements['shiporder'])
   end
 
   def test_namespaces
@@ -114,9 +120,9 @@ class TestSchema < Minitest::Test
   end
 
   def test_schema_type
-    type = schema.types['shiporder']
+    type = schema.types['shiporderType']
 
-    assert_equal('shiporder', type.name)
+    assert_equal('shiporderType', type.name)
     assert_nil(type.namespace)
     assert_equal("Shiporder type documentation", type.annotation)
     assert_instance_of(LibXML::XML::Node, type.node)
@@ -130,22 +136,22 @@ class TestSchema < Minitest::Test
   end
 
   def test_schema_element
-    element = schema.types['shiporder'].elements['orderperson']
+    element = schema.types['shiporderType'].elements['orderperson']
 
     assert_equal('orderperson', element.name)
     assert_nil(element.namespace)
     assert_equal("orderperson element documentation", element.annotation)
 
-    element = schema.types['shiporder'].elements['item']
+    element = schema.types['shiporderType'].elements['item']
     assert_equal('item', element.name)
 
-    element = schema.types['shiporder'].elements['item'].type.elements['note']
+    element = schema.types['shiporderType'].elements['item'].type.elements['note']
     assert_equal('note', element.name)
     assert_equal('string', element.type.name)
   end
 
   def test_schema_attributes
-    type = schema.types['shiporder']
+    type = schema.types['shiporderType']
 
     assert_instance_of(Array, type.attributes)
     assert_equal(2, type.attributes.length)
@@ -153,14 +159,14 @@ class TestSchema < Minitest::Test
   end
 
   def test_schema_attribute
-    attribute = schema.types['shiporder'].attributes.first
+    attribute = schema.types['shiporderType'].attributes.first
 
     assert_equal("orderid", attribute.name)
     assert_nil(attribute.namespace)
     assert_equal(1, attribute.occurs)
     assert_equal('string', attribute.type.name)
 
-    attribute = schema.types['shiporder'].attributes[1]
+    attribute = schema.types['shiporderType'].attributes[1]
     assert_equal(2, attribute.occurs)
     assert_equal('1', attribute.default)
     assert_equal('integer', attribute.type.name)

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -108,10 +108,18 @@ class TestSchema < Minitest::Test
     assert_instance_of(LibXML::XML::Schema::Type, schema.imported_types['shiporderType'])
   end
 
-  def test_imported_elements
-    assert_instance_of(Hash, schema.imported_elements)
-    assert_equal(1, schema.imported_elements.length)
-    assert_instance_of(LibXML::XML::Schema::Element, schema.imported_elements['shiporder'])
+  def test_imported_ns_types
+    assert_instance_of(Hash, schema.imported_ns_types)
+    assert_equal(1, schema.imported_ns_types.length)
+    assert_equal(1, schema.imported_ns_types[nil].length)
+    assert_instance_of(LibXML::XML::Schema::Type, schema.imported_ns_types[nil]['shiporderType'])
+  end
+
+  def test_imported_ns_elements
+    assert_instance_of(Hash, schema.imported_ns_elements)
+    assert_equal(1, schema.imported_ns_elements.length)
+    assert_equal(1, schema.imported_ns_elements[nil].length)
+    assert_instance_of(LibXML::XML::Schema::Element, schema.imported_ns_elements[nil]['shiporder'])
   end
 
   def test_namespaces


### PR DESCRIPTION
Many schemas that use imported schemas for other targeted namespaces allow those other namespace elements to appear within the original targeted namespace.   However, it is not currently possible to find an imported schema type for one of those imported elements without having a list of the imported element names.

Also, it is impossible to distinguish during test whether a value being returned is an elemDecl or a typeDecl when the test names are the same.  Hence the change of the type name for 'shiporder' to be 'shiporderType'.   This allows the test to distinguish whether the element or the type name was returned.