### PR TITLE
Convert some schema method accessors to use instance variables with attr_reader methods.

### DIFF
--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -46,7 +46,23 @@ static void rxml_schema_free(xmlSchemaPtr xschema)
 
 VALUE rxml_wrap_schema(xmlSchemaPtr xschema)
 {
-  return Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+  VALUE class;
+
+  if (!xschema)
+    rb_raise(rb_eArgError, "XML::Schema is required!");
+
+  class = Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+
+  /*
+   * Create these as instance variables to provide the output of inspect/to_str some
+   * idea of what schema this class contains.
+   */
+  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(xschema->targetNamespace));
+  rb_iv_set(class, "@name", QNIL_OR_STRING(xschema->name));
+  rb_iv_set(class, "@id", QNIL_OR_STRING(xschema->id));
+  rb_iv_set(class, "@version", QNIL_OR_STRING(xschema->name));
+
+  return class;
 }
 
 static VALUE rxml_schema_init(VALUE class, xmlSchemaParserCtxtPtr xparser)
@@ -123,43 +139,6 @@ static VALUE rxml_schema_init_from_string(VALUE class, VALUE schema_str)
   return rxml_schema_init(class, xparser);
 }
 
-static VALUE rxml_schema_target_namespace(VALUE self)
-{
-  xmlSchemaPtr xschema;
-
-  Data_Get_Struct(self, xmlSchema, xschema);
-
-  QNIL_OR_STRING(xschema->targetNamespace)
-}
-
-static VALUE rxml_schema_name(VALUE self)
-{
-  xmlSchemaPtr xschema;
-
-  Data_Get_Struct(self, xmlSchema, xschema);
-
-  QNIL_OR_STRING(xschema->name)
-}
-
-static VALUE rxml_schema_version(VALUE self)
-{
-  xmlSchemaPtr xschema;
-
-  Data_Get_Struct(self, xmlSchema, xschema);
-
-  QNIL_OR_STRING(xschema->version)
-}
-
-static VALUE rxml_schema_id(VALUE self)
-{
-  xmlSchemaPtr xschema;
-
-  Data_Get_Struct(self, xmlSchema, xschema);
-
-  QNIL_OR_STRING(xschema->id)
-}
-
-
 /*
  * call-seq:
  *    XML::Schema.document -> document
@@ -235,10 +214,8 @@ static void collect_imported_ns_elements(xmlSchemaImportPtr import, VALUE result
   if (import->imported && import->schema)
   {
     VALUE elements = rb_hash_new();
-    VALUE tns;
     xmlHashScan(import->schema->elemDecl, (xmlHashScanner)scan_schema_element, (void *)elements);
-    tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
-    rb_hash_aset(result, tns, elements);
+    rb_hash_aset(result, QNIL_OR_STRING(import->schema->targetNamespace), elements);
   }
 }
 
@@ -318,10 +295,8 @@ static void collect_imported_ns_types(xmlSchemaImportPtr import, VALUE result, c
   if (import->imported && import->schema)
   {
     VALUE types = rb_hash_new();
-    VALUE tns;
     xmlHashScan(import->schema->typeDecl, (xmlHashScanner)scan_schema_type, (void *)types);
-    tns = (import->schema->targetNamespace) ? rb_str_new2((const char *)import->schema->targetNamespace) : Qnil;
-    rb_hash_aset(result, tns, types);
+    rb_hash_aset(result, QNIL_OR_STRING(import->schema->targetNamespace), types);
   }
 }
 
@@ -353,10 +328,13 @@ void rxml_init_schema(void)
   rb_define_singleton_method(cXMLSchema, "from_string", rxml_schema_init_from_string, 1);
   rb_define_singleton_method(cXMLSchema, "document", rxml_schema_init_from_document, 1);
 
-  rb_define_method(cXMLSchema, "target_namespace", rxml_schema_target_namespace, 0);
-  rb_define_method(cXMLSchema, "name", rxml_schema_name, 0);
-  rb_define_method(cXMLSchema, "id", rxml_schema_id, 0);
-  rb_define_method(cXMLSchema, "version", rxml_schema_version, 0);
+  /* Create attr_reader methods for the above instance variables */
+  rb_define_attr(cXMLSchema, "target_namespace", 1, 0);
+  rb_define_attr(cXMLSchema, "name", 1, 0);
+  rb_define_attr(cXMLSchema, "id", 1, 0);
+  rb_define_attr(cXMLSchema, "version", 1, 0);
+
+  // These are just methods so as to hide their values and not overly clutter the output of inspect/to_str
   rb_define_method(cXMLSchema, "document", rxml_schema_document, 0);
   rb_define_method(cXMLSchema, "namespaces", rxml_schema_namespaces, 0);
   rb_define_method(cXMLSchema, "elements", rxml_schema_elements, 0);

--- a/ext/libxml/ruby_xml_schema.c
+++ b/ext/libxml/ruby_xml_schema.c
@@ -46,23 +46,23 @@ static void rxml_schema_free(xmlSchemaPtr xschema)
 
 VALUE rxml_wrap_schema(xmlSchemaPtr xschema)
 {
-  VALUE class;
+  VALUE result;
 
   if (!xschema)
     rb_raise(rb_eArgError, "XML::Schema is required!");
 
-  class = Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
+  result = Data_Wrap_Struct(cXMLSchema, NULL, rxml_schema_free, xschema);
 
   /*
    * Create these as instance variables to provide the output of inspect/to_str some
    * idea of what schema this class contains.
    */
-  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(xschema->targetNamespace));
-  rb_iv_set(class, "@name", QNIL_OR_STRING(xschema->name));
-  rb_iv_set(class, "@id", QNIL_OR_STRING(xschema->id));
-  rb_iv_set(class, "@version", QNIL_OR_STRING(xschema->name));
+  rb_iv_set(result, "@target_namespace", QNIL_OR_STRING(xschema->targetNamespace));
+  rb_iv_set(result, "@name", QNIL_OR_STRING(xschema->name));
+  rb_iv_set(result, "@id", QNIL_OR_STRING(xschema->id));
+  rb_iv_set(result, "@version", QNIL_OR_STRING(xschema->name));
 
-  return class;
+  return result;
 }
 
 static VALUE rxml_schema_init(VALUE class, xmlSchemaParserCtxtPtr xparser)

--- a/ext/libxml/ruby_xml_schema.h
+++ b/ext/libxml/ruby_xml_schema.h
@@ -9,11 +9,8 @@ extern VALUE cXMLSchema;
 
 void rxml_init_schema(void);
 
-#define QNIL_OR_STRING(slot)			\
-    if (slot == NULL) \
-      return Qnil; \
-    else \
-	    return rb_str_new2((const char *)slot);
+#define QNIL_OR_STRING(slot) \
+    (slot == NULL) ? Qnil : rb_str_new2((const char *)slot)
 
 #define SUBSET_RESTRICTION  1<<0
 #define SUBSET_EXTENSION    1<<1

--- a/ext/libxml/ruby_xml_schema_attribute.c
+++ b/ext/libxml/ruby_xml_schema_attribute.c
@@ -10,27 +10,28 @@ static void rxml_schema_attribute_free(xmlSchemaAttributeUsePtr attr)
   xmlFree(attr);
 }
 
-#define GET_SCHEMA_ATTRIBUTE(attr_ptr, attr_name) \
-    (attr_ptr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) ? \
-        (const char *)(((xmlSchemaAttributeUseProhibPtr) attr_ptr)->attr_name) : \
-            (attr_ptr->type == XML_SCHEMA_EXTRA_QNAMEREF) ? \
-                (const char *)(((xmlSchemaQNameRefPtr) attr_ptr)->attr_name) : \
-                (const char *)((xmlSchemaAttributePtr) (attr_ptr->attrDecl)->attr_name)
-
 VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
 {
   VALUE class;
-  const char *str;
+  const char *tns_str, *name_str;
 
   if (!attr)
     rb_raise(rb_eArgError, "XML::Schema::Attribute required!");
 
   class = Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
 
-  str = GET_SCHEMA_ATTRIBUTE(attr, targetNamespace);
-  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(str));
-  str = GET_SCHEMA_ATTRIBUTE(attr, name);
-  rb_iv_set(class, "@name", QNIL_OR_STRING(str));
+  if (attr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) {
+    tns_str = (const char *)(((xmlSchemaAttributeUseProhibPtr) attr)->targetNamespace);
+    name_str = (const char *)(((xmlSchemaAttributeUseProhibPtr) attr)->name);
+  } else if (attr->type == XML_SCHEMA_EXTRA_QNAMEREF) {
+    tns_str = (const char *)(((xmlSchemaQNameRefPtr) attr)->targetNamespace);
+    name_str = (const char *)(((xmlSchemaQNameRefPtr) attr)->name);
+  } else {
+    tns_str = (const char *)((xmlSchemaAttributePtr) (attr->attrDecl)->targetNamespace);
+    name_str = (const char *)((xmlSchemaAttributePtr) (attr->attrDecl)->name);
+  }
+  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(tns_str));
+  rb_iv_set(class, "@name", QNIL_OR_STRING(name_str));
   rb_iv_set(class, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr)attr->attrDecl->subtypes));
   rb_iv_set(class, "@value", QNIL_OR_STRING(attr->defValue));
   rb_iv_set(class, "@occurs", INT2NUM(attr->occurs));
@@ -38,7 +39,7 @@ VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
   return class;
 }
 
-static VALUE rexml_schema_attribute_node(VALUE self)
+static VALUE rxml_schema_attribute_node(VALUE self)
 {
   xmlSchemaAttributeUsePtr attr;
 
@@ -56,5 +57,5 @@ void rxml_init_schema_attribute(void)
   rb_define_attr(cXMLSchemaAttribute, "value", 1, 0);
   rb_define_attr(cXMLSchemaAttribute, "occurs", 1, 0);
 
-  rb_define_method(cXMLSchemaAttribute, "node", rexml_schema_attribute_node, 0);
+  rb_define_method(cXMLSchemaAttribute, "node", rxml_schema_attribute_node, 0);
 }

--- a/ext/libxml/ruby_xml_schema_attribute.c
+++ b/ext/libxml/ruby_xml_schema_attribute.c
@@ -12,13 +12,13 @@ static void rxml_schema_attribute_free(xmlSchemaAttributeUsePtr attr)
 
 VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
 {
-  VALUE class;
+  VALUE result;
   const xmlChar *tns_str, *name_str;
 
   if (!attr)
     rb_raise(rb_eArgError, "XML::Schema::Attribute required!");
 
-  class = Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
+  result = Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
 
   if (attr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) {
     tns_str = ((xmlSchemaAttributeUseProhibPtr) attr)->targetNamespace;
@@ -30,13 +30,13 @@ VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
     tns_str = ((xmlSchemaAttributePtr) (attr->attrDecl))->targetNamespace;
     name_str = ((xmlSchemaAttributePtr) (attr->attrDecl))->name;
   }
-  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(tns_str));
-  rb_iv_set(class, "@name", QNIL_OR_STRING(name_str));
-  rb_iv_set(class, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr)attr->attrDecl->subtypes));
-  rb_iv_set(class, "@value", QNIL_OR_STRING(attr->defValue));
-  rb_iv_set(class, "@occurs", INT2NUM(attr->occurs));
+  rb_iv_set(result, "@target_namespace", QNIL_OR_STRING(tns_str));
+  rb_iv_set(result, "@name", QNIL_OR_STRING(name_str));
+  rb_iv_set(result, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr)attr->attrDecl->subtypes));
+  rb_iv_set(result, "@value", QNIL_OR_STRING(attr->defValue));
+  rb_iv_set(result, "@occurs", INT2NUM(attr->occurs));
 
-  return class;
+  return result;
 }
 
 static VALUE rxml_schema_attribute_node(VALUE self)

--- a/ext/libxml/ruby_xml_schema_attribute.c
+++ b/ext/libxml/ruby_xml_schema_attribute.c
@@ -10,67 +10,35 @@ static void rxml_schema_attribute_free(xmlSchemaAttributeUsePtr attr)
   xmlFree(attr);
 }
 
+#define GET_SCHEMA_ATTRIBUTE(attr_ptr, attr_name) \
+    (attr_ptr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) ? \
+        (const char *)(((xmlSchemaAttributeUseProhibPtr) attr_ptr)->attr_name) : \
+            (attr_ptr->type == XML_SCHEMA_EXTRA_QNAMEREF) ? \
+                (const char *)(((xmlSchemaQNameRefPtr) attr_ptr)->attr_name) : \
+                (const char *)((xmlSchemaAttributePtr) (attr_ptr->attrDecl)->attr_name)
+
 VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
 {
-  return Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
+  VALUE class;
+  const char *str;
+
+  if (!attr)
+    rb_raise(rb_eArgError, "XML::Schema::Attribute required!");
+
+  class = Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
+
+  str = GET_SCHEMA_ATTRIBUTE(attr, targetNamespace);
+  rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(str));
+  str = GET_SCHEMA_ATTRIBUTE(attr, name);
+  rb_iv_set(class, "@name", QNIL_OR_STRING(str));
+  rb_iv_set(class, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr)attr->attrDecl->subtypes));
+  rb_iv_set(class, "@value", QNIL_OR_STRING(attr->defValue));
+  rb_iv_set(class, "@occurs", INT2NUM(attr->occurs));
+
+  return class;
 }
 
-static VALUE rxml_schema_attribute_namespace(VALUE self)
-{
-  xmlSchemaAttributeUsePtr attr;
-  const xmlChar *tns;
-
-  Data_Get_Struct(self, xmlSchemaAttributeUse, attr);
-
-  if (attr == NULL)
-    return Qnil;
-
-  if (attr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) {
-      tns = ((xmlSchemaAttributeUseProhibPtr) attr)->targetNamespace;
-  } else if (attr->type == XML_SCHEMA_EXTRA_QNAMEREF) {
-      tns = ((xmlSchemaQNameRefPtr) attr)->targetNamespace;
-  } else {
-      tns = ((xmlSchemaAttributePtr) ((xmlSchemaAttributeUsePtr) (attr))->attrDecl)->targetNamespace;
-  }
-
-  QNIL_OR_STRING(tns)
-}
-
-static VALUE rxml_schema_attribute_name(VALUE self)
-{
-  xmlSchemaAttributeUsePtr attr;
-  const xmlChar *name;
-
-  Data_Get_Struct(self, xmlSchemaAttributeUse, attr);
-
-  if (attr == NULL)
-    return Qnil;
-
-  if (attr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) {
-      name = ((xmlSchemaAttributeUseProhibPtr) attr)->name;
-  } else if (attr->type == XML_SCHEMA_EXTRA_QNAMEREF) {
-      name = ((xmlSchemaQNameRefPtr) attr)->name;
-  } else {
-      xmlSchemaAttributePtr attrDecl = ((xmlSchemaAttributeUsePtr) attr)->attrDecl;
-      name = attrDecl->name;
-  }
-
-  QNIL_OR_STRING(name)
-}
-
-static VALUE rxml_schema_attribute_type(VALUE self)
-{
-  xmlSchemaAttributeUsePtr attr;
-  xmlSchemaTypePtr xtype;
-
-  Data_Get_Struct(self, xmlSchemaAttributeUse, attr);
-
-  xtype = attr->attrDecl->subtypes;
-
-  return rxml_wrap_schema_type((xmlSchemaTypePtr) xtype);
-}
-
-static VALUE rxml_schema_attribute_node(VALUE self)
+static VALUE rexml_schema_attribute_node(VALUE self)
 {
   xmlSchemaAttributeUsePtr attr;
 
@@ -79,31 +47,14 @@ static VALUE rxml_schema_attribute_node(VALUE self)
   return rxml_node_wrap(attr->node);
 }
 
-static VALUE rxml_schema_attribute_value(VALUE self)
-{
-  xmlSchemaAttributeUsePtr attr;
-
-  Data_Get_Struct(self, xmlSchemaAttributeUse, attr);
-
-  QNIL_OR_STRING(attr->defValue)
-}
-
-static VALUE rxml_schema_attribute_occurs(VALUE self)
-{
-  xmlSchemaAttributeUsePtr attr;
-
-  Data_Get_Struct(self, xmlSchemaAttributeUse, attr);
-
-  return INT2NUM(attr->occurs);
-}
-
 void rxml_init_schema_attribute(void)
 {
   cXMLSchemaAttribute = rb_define_class_under(cXMLSchema, "Attribute", rb_cObject);
-  rb_define_method(cXMLSchemaAttribute, "namespace", rxml_schema_attribute_namespace, 0);
-  rb_define_method(cXMLSchemaAttribute, "name", rxml_schema_attribute_name, 0);
-  rb_define_method(cXMLSchemaAttribute, "type", rxml_schema_attribute_type, 0);
-  rb_define_method(cXMLSchemaAttribute, "node", rxml_schema_attribute_node, 0);
-  rb_define_method(cXMLSchemaAttribute, "value", rxml_schema_attribute_value, 0);
-  rb_define_method(cXMLSchemaAttribute, "occurs", rxml_schema_attribute_occurs, 0);
+  rb_define_attr(cXMLSchemaAttribute, "name", 1, 0);
+  rb_define_attr(cXMLSchemaAttribute, "type", 1, 0);
+  rb_define_attr(cXMLSchemaAttribute, "namespace", 1, 0);
+  rb_define_attr(cXMLSchemaAttribute, "value", 1, 0);
+  rb_define_attr(cXMLSchemaAttribute, "occurs", 1, 0);
+
+  rb_define_method(cXMLSchemaAttribute, "node", rexml_schema_attribute_node, 0);
 }

--- a/ext/libxml/ruby_xml_schema_attribute.c
+++ b/ext/libxml/ruby_xml_schema_attribute.c
@@ -13,7 +13,7 @@ static void rxml_schema_attribute_free(xmlSchemaAttributeUsePtr attr)
 VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
 {
   VALUE class;
-  const char *tns_str, *name_str;
+  const xmlChar *tns_str, *name_str;
 
   if (!attr)
     rb_raise(rb_eArgError, "XML::Schema::Attribute required!");
@@ -21,14 +21,14 @@ VALUE rxml_wrap_schema_attribute(xmlSchemaAttributeUsePtr attr)
   class = Data_Wrap_Struct(cXMLSchemaAttribute, NULL, rxml_schema_attribute_free, attr);
 
   if (attr->type == XML_SCHEMA_EXTRA_ATTR_USE_PROHIB) {
-    tns_str = (const char *)(((xmlSchemaAttributeUseProhibPtr) attr)->targetNamespace);
-    name_str = (const char *)(((xmlSchemaAttributeUseProhibPtr) attr)->name);
+    tns_str = ((xmlSchemaAttributeUseProhibPtr) attr)->targetNamespace;
+    name_str = ((xmlSchemaAttributeUseProhibPtr) attr)->name;
   } else if (attr->type == XML_SCHEMA_EXTRA_QNAMEREF) {
-    tns_str = (const char *)(((xmlSchemaQNameRefPtr) attr)->targetNamespace);
-    name_str = (const char *)(((xmlSchemaQNameRefPtr) attr)->name);
+    tns_str = ((xmlSchemaQNameRefPtr) attr)->targetNamespace;
+    name_str = ((xmlSchemaQNameRefPtr) attr)->name;
   } else {
-    tns_str = (const char *)((xmlSchemaAttributePtr) (attr->attrDecl)->targetNamespace);
-    name_str = (const char *)((xmlSchemaAttributePtr) (attr->attrDecl)->name);
+    tns_str = ((xmlSchemaAttributePtr) (attr->attrDecl))->targetNamespace;
+    name_str = ((xmlSchemaAttributePtr) (attr->attrDecl))->name;
   }
   rb_iv_set(class, "@target_namespace", QNIL_OR_STRING(tns_str));
   rb_iv_set(class, "@name", QNIL_OR_STRING(name_str));

--- a/ext/libxml/ruby_xml_schema_element.c
+++ b/ext/libxml/ruby_xml_schema_element.c
@@ -12,19 +12,19 @@ static void rxml_schema_element_free(xmlSchemaElementPtr xschema_element)
 
 VALUE rxml_wrap_schema_element(xmlSchemaElementPtr xelem)
 {
-  VALUE class;
+  VALUE result;
 
   if (!xelem)
     rb_raise(rb_eArgError, "XML::Schema::Element is required!");
 
-  class = Data_Wrap_Struct(cXMLSchemaElement, NULL, rxml_schema_element_free, xelem);
+  result = Data_Wrap_Struct(cXMLSchemaElement, NULL, rxml_schema_element_free, xelem);
 
-  rb_iv_set(class, "@name", QNIL_OR_STRING(xelem->name));
-  rb_iv_set(class, "@value", QNIL_OR_STRING(xelem->value));
-  rb_iv_set(class, "@namespace", QNIL_OR_STRING(xelem->targetNamespace));
-  rb_iv_set(class, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr) (xelem->subtypes)));
+  rb_iv_set(result, "@name", QNIL_OR_STRING(xelem->name));
+  rb_iv_set(result, "@value", QNIL_OR_STRING(xelem->value));
+  rb_iv_set(result, "@namespace", QNIL_OR_STRING(xelem->targetNamespace));
+  rb_iv_set(result, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr) (xelem->subtypes)));
 
-  return class;
+  return result;
 }
 
 static VALUE rxml_schema_element_node(VALUE self)

--- a/ext/libxml/ruby_xml_schema_element.c
+++ b/ext/libxml/ruby_xml_schema_element.c
@@ -27,7 +27,7 @@ VALUE rxml_wrap_schema_element(xmlSchemaElementPtr xelem)
   return class;
 }
 
-static VALUE rexml_schema_element_node(VALUE self)
+static VALUE rxml_schema_element_node(VALUE self)
 {
   xmlSchemaElementPtr xelem;
 
@@ -36,7 +36,7 @@ static VALUE rexml_schema_element_node(VALUE self)
   return rxml_node_wrap(xelem->node);
 }
 
-static VALUE rexml_schema_element_annot(VALUE self)
+static VALUE rxml_schema_element_annot(VALUE self)
 {
   xmlSchemaElementPtr xelem;
   VALUE annotation = Qnil;
@@ -64,6 +64,6 @@ void rxml_init_schema_element(void)
   rb_define_attr(cXMLSchemaElement, "namespace", 1, 0);
   rb_define_attr(cXMLSchemaElement, "type", 1, 0);
 
-  rb_define_method(cXMLSchemaElement, "node", rexml_schema_element_node, 0);
-  rb_define_method(cXMLSchemaElement, "annotation", rexml_schema_element_annot, 0);
+  rb_define_method(cXMLSchemaElement, "node", rxml_schema_element_node, 0);
+  rb_define_method(cXMLSchemaElement, "annotation", rxml_schema_element_annot, 0);
 }

--- a/ext/libxml/ruby_xml_schema_element.c
+++ b/ext/libxml/ruby_xml_schema_element.c
@@ -10,43 +10,24 @@ static void rxml_schema_element_free(xmlSchemaElementPtr xschema_element)
   xmlFree(xschema_element);
 }
 
-VALUE rxml_wrap_schema_element(xmlSchemaElementPtr xelement)
+VALUE rxml_wrap_schema_element(xmlSchemaElementPtr xelem)
 {
-  return Data_Wrap_Struct(cXMLSchemaElement, NULL, rxml_schema_element_free, xelement);
+  VALUE class;
+
+  if (!xelem)
+    rb_raise(rb_eArgError, "XML::Schema::Element is required!");
+
+  class = Data_Wrap_Struct(cXMLSchemaElement, NULL, rxml_schema_element_free, xelem);
+
+  rb_iv_set(class, "@name", QNIL_OR_STRING(xelem->name));
+  rb_iv_set(class, "@value", QNIL_OR_STRING(xelem->value));
+  rb_iv_set(class, "@namespace", QNIL_OR_STRING(xelem->targetNamespace));
+  rb_iv_set(class, "@type", rxml_wrap_schema_type((xmlSchemaTypePtr) (xelem->subtypes)));
+
+  return class;
 }
 
-static VALUE rxml_schema_element_namespace(VALUE self)
-{
-  xmlSchemaElementPtr xelem;
-
-  Data_Get_Struct(self, xmlSchemaElement, xelem);
-
-  QNIL_OR_STRING(xelem->targetNamespace)
-}
-
-static VALUE rxml_schema_element_name(VALUE self)
-{
-  xmlSchemaElementPtr xelem;
-
-  Data_Get_Struct(self, xmlSchemaElement, xelem);
-
-
-  QNIL_OR_STRING(xelem->name)
-}
-
-static VALUE rxml_schema_element_type(VALUE self)
-{
-  xmlSchemaElementPtr xelem;
-  xmlSchemaTypePtr xtype;
-
-  Data_Get_Struct(self, xmlSchemaElement, xelem);
-
-  xtype = xelem->subtypes;
-
-  return rxml_wrap_schema_type((xmlSchemaTypePtr) xtype);
-}
-
-static VALUE rxml_schema_element_node(VALUE self)
+static VALUE rexml_schema_element_node(VALUE self)
 {
   xmlSchemaElementPtr xelem;
 
@@ -55,41 +36,34 @@ static VALUE rxml_schema_element_node(VALUE self)
   return rxml_node_wrap(xelem->node);
 }
 
-static VALUE rxml_schema_element_value(VALUE self)
+static VALUE rexml_schema_element_annot(VALUE self)
 {
   xmlSchemaElementPtr xelem;
+  VALUE annotation = Qnil;
 
   Data_Get_Struct(self, xmlSchemaElement, xelem);
 
-  QNIL_OR_STRING(xelem->value)
-}
+  if ((xelem->annot != NULL) && (xelem->annot->content != NULL))
+  {
+    xmlChar *content = xmlNodeGetContent(xelem->annot->content);
+    if (content)
+    {
+      annotation = rxml_new_cstr(content, NULL);
+      xmlFree(content);
+    }
+  }
 
-static VALUE rxml_schema_element_annot(VALUE self)
-{
-	VALUE result = Qnil;
-	xmlSchemaElementPtr xelem;
-
-	Data_Get_Struct(self, xmlSchemaElement, xelem);
-
-	if (xelem != NULL && xelem->annot != NULL && xelem->annot->content != NULL)
-	{
-		xmlChar *content = xmlNodeGetContent(xelem->annot->content);
-		if (content)
-		{
-			result = rxml_new_cstr(content, NULL);
-			xmlFree(content);
-		}
-	}
-	return result;
+  return annotation;
 }
 
 void rxml_init_schema_element(void)
 {
   cXMLSchemaElement = rb_define_class_under(cXMLSchema, "Element", rb_cObject);
-  rb_define_method(cXMLSchemaElement, "namespace", rxml_schema_element_namespace, 0);
-  rb_define_method(cXMLSchemaElement, "name", rxml_schema_element_name, 0);
-  rb_define_method(cXMLSchemaElement, "type", rxml_schema_element_type, 0);
-  rb_define_method(cXMLSchemaElement, "node", rxml_schema_element_node, 0);
-  rb_define_method(cXMLSchemaElement, "value", rxml_schema_element_value, 0);
-  rb_define_method(cXMLSchemaElement, "annotation", rxml_schema_element_annot, 0);
+  rb_define_attr(cXMLSchemaElement, "name", 1, 0);
+  rb_define_attr(cXMLSchemaElement, "value", 1, 0);
+  rb_define_attr(cXMLSchemaElement, "namespace", 1, 0);
+  rb_define_attr(cXMLSchemaElement, "type", 1, 0);
+
+  rb_define_method(cXMLSchemaElement, "node", rexml_schema_element_node, 0);
+  rb_define_method(cXMLSchemaElement, "annotation", rexml_schema_element_annot, 0);
 }

--- a/ext/libxml/ruby_xml_schema_facet.c
+++ b/ext/libxml/ruby_xml_schema_facet.c
@@ -11,17 +11,17 @@ static void rxml_schema_facet_free(xmlSchemaFacetPtr xschema_type)
 
 VALUE rxml_wrap_schema_facet(xmlSchemaFacetPtr facet)
 {
-  VALUE class;
+  VALUE result;
 
   if (!facet)
     rb_raise(rb_eArgError, "XML::Schema::Facet required!");
 
-  class = Data_Wrap_Struct(cXMLSchemaFacet, NULL, rxml_schema_facet_free, facet);
+  result = Data_Wrap_Struct(cXMLSchemaFacet, NULL, rxml_schema_facet_free, facet);
 
-  rb_iv_set(class, "@kind", INT2NUM(facet->type));
-  rb_iv_set(class, "@value", QNIL_OR_STRING(facet->value));
+  rb_iv_set(result, "@kind", INT2NUM(facet->type));
+  rb_iv_set(result, "@value", QNIL_OR_STRING(facet->value));
 
-  return class;
+  return result;
 
 }
 

--- a/ext/libxml/ruby_xml_schema_facet.c
+++ b/ext/libxml/ruby_xml_schema_facet.c
@@ -9,6 +9,22 @@ static void rxml_schema_facet_free(xmlSchemaFacetPtr xschema_type)
   xmlFree(xschema_type);
 }
 
+VALUE rxml_wrap_schema_facet(xmlSchemaFacetPtr facet)
+{
+  VALUE class;
+
+  if (!facet)
+    rb_raise(rb_eArgError, "XML::Schema::Facet required!");
+
+  class = Data_Wrap_Struct(cXMLSchemaFacet, NULL, rxml_schema_facet_free, facet);
+
+  rb_iv_set(class, "@kind", INT2NUM(facet->type));
+  rb_iv_set(class, "@value", QNIL_OR_STRING(facet->value));
+
+  return class;
+
+}
+
 /* START FACET*/
 
 static VALUE rxml_schema_facet_node(VALUE self)
@@ -20,33 +36,11 @@ static VALUE rxml_schema_facet_node(VALUE self)
   return rxml_node_wrap(facet->node);
 }
 
-static VALUE rxml_schema_facet_value(VALUE self)
-{
-  xmlSchemaFacetPtr facet;
-
-  Data_Get_Struct(self, xmlSchemaFacet, facet);
-
-  QNIL_OR_STRING(facet->value)
-}
-
-static VALUE rxml_schema_facet_kind(VALUE self)
-{
-  xmlSchemaFacetPtr facet;
-
-  Data_Get_Struct(self, xmlSchemaFacet, facet);
-
-  return INT2NUM(facet->type);
-}
-
-VALUE rxml_wrap_schema_facet(xmlSchemaFacetPtr facet)
-{
-  return Data_Wrap_Struct(cXMLSchemaFacet, NULL, rxml_schema_facet_free, facet);
-}
-
 void rxml_init_schema_facet(void)
 {
   cXMLSchemaFacet = rb_define_class_under(cXMLSchema, "Facet", rb_cObject);
-  rb_define_method(cXMLSchemaFacet, "value", rxml_schema_facet_value, 0);
+  rb_define_attr(cXMLSchemaFacet, "kind", 1, 0);
+  rb_define_attr(cXMLSchemaFacet, "value", 1, 0);
+
   rb_define_method(cXMLSchemaFacet, "node", rxml_schema_facet_node, 0);
-  rb_define_method(cXMLSchemaFacet, "kind", rxml_schema_facet_kind, 0);
 }

--- a/ext/libxml/ruby_xml_schema_type.c
+++ b/ext/libxml/ruby_xml_schema_type.c
@@ -17,18 +17,18 @@ static void rxml_schema_type_free(xmlSchemaTypePtr xschema_type)
 
 VALUE rxml_wrap_schema_type(xmlSchemaTypePtr xtype)
 {
-  VALUE class;
+  VALUE result;
 
   if (!xtype)
     rb_raise(rb_eArgError, "XML::Schema::Type required!");
 
-  class = Data_Wrap_Struct(cXMLSchemaType, NULL, rxml_schema_type_free, xtype);
+  result = Data_Wrap_Struct(cXMLSchemaType, NULL, rxml_schema_type_free, xtype);
 
-  rb_iv_set(class, "@name", QNIL_OR_STRING(xtype->name));
-  rb_iv_set(class, "@namespace", QNIL_OR_STRING(xtype->targetNamespace));
-  rb_iv_set(class, "@kind", INT2NUM(xtype->type));
+  rb_iv_set(result, "@name", QNIL_OR_STRING(xtype->name));
+  rb_iv_set(result, "@namespace", QNIL_OR_STRING(xtype->targetNamespace));
+  rb_iv_set(result, "@kind", INT2NUM(xtype->type));
 
-  return class;
+  return result;
 }
 
 static VALUE rxml_schema_type_base(VALUE self)

--- a/ext/libxml/ruby_xml_schema_type.c
+++ b/ext/libxml/ruby_xml_schema_type.c
@@ -17,25 +17,18 @@ static void rxml_schema_type_free(xmlSchemaTypePtr xschema_type)
 
 VALUE rxml_wrap_schema_type(xmlSchemaTypePtr xtype)
 {
-  return Data_Wrap_Struct(cXMLSchemaType, NULL, rxml_schema_type_free, xtype);
-}
+  VALUE class;
 
-static VALUE rxml_schema_type_namespace(VALUE self)
-{
-  xmlSchemaTypePtr xtype;
+  if (!xtype)
+    rb_raise(rb_eArgError, "XML::Schema::Type required!");
 
-  Data_Get_Struct(self, xmlSchemaType, xtype);
+  class = Data_Wrap_Struct(cXMLSchemaType, NULL, rxml_schema_type_free, xtype);
 
-  QNIL_OR_STRING(xtype->targetNamespace)
-}
+  rb_iv_set(class, "@name", QNIL_OR_STRING(xtype->name));
+  rb_iv_set(class, "@namespace", QNIL_OR_STRING(xtype->targetNamespace));
+  rb_iv_set(class, "@kind", INT2NUM(xtype->type));
 
-static VALUE rxml_schema_type_name(VALUE self)
-{
-  xmlSchemaTypePtr xtype;
-
-  Data_Get_Struct(self, xmlSchemaType, xtype);
-
-  QNIL_OR_STRING(xtype->name)
+  return class;
 }
 
 static VALUE rxml_schema_type_base(VALUE self)
@@ -44,7 +37,16 @@ static VALUE rxml_schema_type_base(VALUE self)
 
   Data_Get_Struct(self, xmlSchemaType, xtype);
 
-  return Data_Wrap_Struct(cXMLSchemaType, NULL, rxml_schema_type_free, xtype->baseType);
+  return (xtype->baseType != xtype) ? rxml_wrap_schema_type(xtype->baseType) : Qnil;
+}
+
+static VALUE rxml_schema_type_node(VALUE self)
+{
+  xmlSchemaTypePtr xtype;
+
+  Data_Get_Struct(self, xmlSchemaType, xtype);
+
+  return (xtype->node != NULL) ? rxml_node_wrap(xtype->node) : Qnil;
 }
 
 static VALUE rxml_schema_type_facets(VALUE self)
@@ -66,27 +68,6 @@ static VALUE rxml_schema_type_facets(VALUE self)
   }
 
   return result;
-}
-
-static VALUE rxml_schema_type_node(VALUE self)
-{
-  xmlSchemaTypePtr xtype;
-
-  Data_Get_Struct(self, xmlSchemaType, xtype);
-
-  if(xtype->node != NULL)
-    return rxml_node_wrap(xtype->node);
-  else
-    return Qnil;
-}
-
-static VALUE rxml_schema_type_kind(VALUE self)
-{
-  xmlSchemaTypePtr xtype;
-
-  Data_Get_Struct(self, xmlSchemaType, xtype);
-
-  return INT2NUM(xtype->type);
 }
 
 static VALUE rxml_schema_type_annot(VALUE self)
@@ -220,13 +201,14 @@ void rxml_init_schema_type(void)
 
   cXMLSchemaType = rb_define_class_under(cXMLSchema, "Type", rb_cObject);
 
-  rb_define_method(cXMLSchemaType, "namespace", rxml_schema_type_namespace, 0);
-  rb_define_method(cXMLSchemaType, "name", rxml_schema_type_name, 0);
+  rb_define_attr(cXMLSchemaType, "namespace", 1, 0);
+  rb_define_attr(cXMLSchemaType, "name", 1, 0);
+  rb_define_attr(cXMLSchemaType, "kind", 1, 0);
+
+  rb_define_method(cXMLSchemaType, "base", rxml_schema_type_base, 0);
+  rb_define_method(cXMLSchemaType, "node", rxml_schema_type_node, 0);
   rb_define_method(cXMLSchemaType, "elements", rxml_schema_type_elements, 0);
   rb_define_method(cXMLSchemaType, "attributes", rxml_schema_type_attributes, 0);
-  rb_define_method(cXMLSchemaType, "base", rxml_schema_type_base, 0);
-  rb_define_method(cXMLSchemaType, "kind", rxml_schema_type_kind, 0);
-  rb_define_method(cXMLSchemaType, "node", rxml_schema_type_node, 0);
   rb_define_method(cXMLSchemaType, "facets", rxml_schema_type_facets, 0);
   rb_define_method(cXMLSchemaType, "annotation", rxml_schema_type_annot, 0);
 }


### PR DESCRIPTION
The primary reason for this change is to make debugging easier.   The default Ruby to_str method will list an object with it's instance variables.   In example, the following is what a Schema::Element object looks like without using instance variables:
```
(byebug) schema_elem
#<LibXML::XML::Schema::Element:0x0000562ceedd4c00>
```
whereas with instance variables it would look like:
```
(byebug) schema_elem
#<LibXML::XML::Schema::Element:0x000056226531b2c0 @name="manifest", @value=nil, @namespace="http://www.imsproject.org/xsd/imscp_rootv1p1p2", @type=#<LibXML::XML::Schema::Type:0x000056226531ad48 @name="manifestType", @kind=5, @namespace="http://www.imsproject.org/xsd/imscp_rootv1p1p2">>
```
Note: I did not convert all the methods to use instance variables because some of those methods returned complex objects in themselves and that then starts to defeat the purpose of having a more "readable" object.   So, I specifically chose to only attributes that helped identify the object.

From a performance perspective, the key advantage to using instance variables is that they effectively cache the lookup/creation of the object for any particular access method.   Since the Schema tree is parsed and created at initialization  time, it would actually make sense to load all the objects into instance variables since they would never change after initialization.   However, given the typical usage of Schema objects in the first place, I do not feel performance is really a relevant reason for doing any of this - it's more for the convenience of being able to more easily identify objects when debugging.

Thanks!