### PR TITLE
Add support for libxml2 version 2.10.2

### DIFF
--- a/ext/libxml/ruby_libxml.h
+++ b/ext/libxml/ruby_libxml.h
@@ -15,6 +15,7 @@
 #include <libxml/HTMLparser.h>
 #include <libxml/xmlreader.h>
 #include <libxml/c14n.h>
+#include <libxml/xlink.h>
 
 #include <ruby/encoding.h>
 

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -167,11 +167,11 @@ class TestXml < Minitest::Test
   end
 
   def test_enabled_docbook
-    assert(LibXML::XML.enabled_docbook?)
+    refute(LibXML::XML.enabled_docbook?)
   end
 
   def test_enabled_ftp
-    assert(LibXML::XML.enabled_ftp?)
+    refute(LibXML::XML.enabled_ftp?)
   end
 
   def test_enabled_http
@@ -242,7 +242,7 @@ class TestXml < Minitest::Test
   end
 
   def test_libxml_parser_features
-    assert_instance_of(Array, LibXML::XML.features)
+    assert_nil(LibXML::XML.features)
   end
 
   def test_default_options


### PR DESCRIPTION
- Add include for `xlink.h` to solve compilation error `unknown type name ‘xlinkType’`. See commit `ebb17970` ("Remove unneeded #includes") in the libxml2 source code which removed this include.
- FTP support and legacy modules have been disabled by default (see commit `776b0028` in libxml2). The test was updated accordingly.
- Docbook has been disabled by default (see commit `aeaf02c0` in libxml2). The test was updated accordingly.