### PR TITLE
Revert "Store exception to local object for easier debugging." that warns

### DIFF
--- a/lib/libxml-ruby.rb
+++ b/lib/libxml-ruby.rb
@@ -4,7 +4,7 @@
 begin
   RUBY_VERSION =~ /(\d+.\d+)/
   require "#{$1}/libxml_ruby"
-rescue LoadError => e
+rescue LoadError
   require "libxml_ruby"
 end
 


### PR DESCRIPTION
This reverts commit 332fd1db337db905bf4b17191f3d7ca76f629cd0.

Because this causes "assigned but unused variable" warning when libxml-ruby 3.2.4 is being required with `-W`.

```
$ ruby -we "require'libxml-ruby'"
.../libxml-ruby-3.2.4/lib/libxml-ruby.rb:7: warning: assigned but unused variable - e
```
