### PR TITLE
Fix Schema::Element required? and array? methods

### DIFF
--- a/lib/libxml/schema/element.rb
+++ b/lib/libxml/schema/element.rb
@@ -3,6 +3,14 @@
 module LibXML
   module XML
     class Schema::Element
+      def min_occurs
+        @min
+      end
+
+      def max_occurs
+        @max
+      end
+
       def required?
         !min_occurs.zero?
       end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -198,13 +198,19 @@ class TestSchema < Minitest::Test
     assert_equal('orderperson', element.name)
     assert_nil(element.namespace)
     assert_equal("orderperson element documentation", element.annotation)
+    assert_equal(false, element.array?)
+    assert_equal(true, element.required?)
 
     element = @schema.types['shiporderType'].elements['item']
     assert_equal('item', element.name)
+    assert_equal(true, element.array?)
+    assert_equal(true, element.required?)
 
     element = @schema.types['shiporderType'].elements['item'].type.elements['note']
     assert_equal('note', element.name)
     assert_equal('string', element.type.name)
+    assert_equal(false, element.array?)
+    assert_equal(false, element.required?)
   end
 
   def test_schema_attributes


### PR DESCRIPTION
In [this commit](https://github.com/xml4r/libxml-ruby/commit/133096bc7adfb1b9ca5be2e49e623c8880fec9ee#diff-ff32e4dff2433e31f170b6f43842c940bec1c3581a07a5e3bc44887ce973fcc0L67-L76) the `min_occurs` and `max_occurs` getters were removed, saying they were "invalid". The additional message in [HISTORY](https://github.com/xml4r/libxml-ruby/blob/master/HISTORY#L63C111-L63C111) states:

> Remove SchemaElement#minOccurs and SchemaElement#maxOccurs since they actually did not work (Charlie Savage)

[Additional history here](https://github.com/search?q=repo%3Axml4r%2Flibxml-ruby+min_occurs&type=commits)

I'm not aware of any more context surrounding the change, but those methods were still referenced by the Schema::Element's `array?` and `required?` methods. This PR adds tests for those two methods and adds simple ivar reader methods to replace those removed C methods.