### PR TITLE
Fix Ruby warnings about t data classes

### DIFF
--- a/ext/libxml/ruby_xml_attr_decl.c
+++ b/ext/libxml/ruby_xml_attr_decl.c
@@ -143,6 +143,7 @@ VALUE rxml_attr_decl_value_get(VALUE self)
 void rxml_init_attr_decl(void)
 {
   cXMLAttrDecl = rb_define_class_under(mXML, "AttrDecl", rb_cObject);
+  rb_undef_alloc_func(cXMLAttrDecl);
   rb_define_method(cXMLAttrDecl, "doc", rxml_attr_decl_doc_get, 0);
   rb_define_method(cXMLAttrDecl, "name", rxml_attr_decl_name_get, 0);
   rb_define_method(cXMLAttrDecl, "next", rxml_attr_decl_next_get, 0);

--- a/ext/libxml/ruby_xml_attributes.c
+++ b/ext/libxml/ruby_xml_attributes.c
@@ -263,6 +263,7 @@ static VALUE rxml_attributes_first(VALUE self)
 void rxml_init_attributes(void)
 {
   cXMLAttributes = rb_define_class_under(mXML, "Attributes", rb_cObject);
+  rb_undef_alloc_func(cXMLAttributes);
   rb_include_module(cXMLAttributes, rb_mEnumerable);
   rb_define_method(cXMLAttributes, "node", rxml_attributes_node_get, 0);
   rb_define_method(cXMLAttributes, "get_attribute", rxml_attributes_get_attribute, 1);

--- a/ext/libxml/ruby_xml_schema_attribute.c
+++ b/ext/libxml/ruby_xml_schema_attribute.c
@@ -97,6 +97,7 @@ static VALUE rxml_schema_attribute_node(VALUE self)
 void rxml_init_schema_attribute(void)
 {
   cXMLSchemaAttribute = rb_define_class_under(cXMLSchema, "Attribute", rb_cObject);
+  rb_undef_alloc_func(cXMLSchemaAttribute);
   rb_define_attr(cXMLSchemaAttribute, "name", 1, 0);
   rb_define_attr(cXMLSchemaAttribute, "type", 1, 0);
   rb_define_attr(cXMLSchemaAttribute, "namespace", 1, 0);

--- a/ext/libxml/ruby_xml_schema_element.c
+++ b/ext/libxml/ruby_xml_schema_element.c
@@ -59,6 +59,7 @@ static VALUE rxml_schema_element_annot(VALUE self)
 void rxml_init_schema_element(void)
 {
   cXMLSchemaElement = rb_define_class_under(cXMLSchema, "Element", rb_cObject);
+  rb_undef_alloc_func(cXMLSchemaElement);
   rb_define_attr(cXMLSchemaElement, "name", 1, 0);
   rb_define_attr(cXMLSchemaElement, "value", 1, 0);
   rb_define_attr(cXMLSchemaElement, "namespace", 1, 0);

--- a/ext/libxml/ruby_xml_schema_type.c
+++ b/ext/libxml/ruby_xml_schema_type.c
@@ -237,6 +237,7 @@ void rxml_init_schema_type(void)
   #endif
 
   cXMLSchemaType = rb_define_class_under(cXMLSchema, "Type", rb_cObject);
+  rb_undef_alloc_func(cXMLSchemaType);
 
   rb_define_attr(cXMLSchemaType, "namespace", 1, 0);
   rb_define_attr(cXMLSchemaType, "name", 1, 0);

--- a/ext/libxml/ruby_xml_xpath_object.c
+++ b/ext/libxml/ruby_xml_xpath_object.c
@@ -322,6 +322,7 @@ static VALUE rxml_xpath_object_debug(VALUE self)
 void rxml_init_xpath_object(void)
 {
   cXMLXPathObject = rb_define_class_under(mXPath, "Object", rb_cObject);
+  rb_undef_alloc_func(cXMLXPathObject);
   rb_include_module(cXMLXPathObject, rb_mEnumerable);
   rb_define_attr(cXMLXPathObject, "context", 1, 0);
   rb_define_method(cXMLXPathObject, "each", rxml_xpath_object_each, 0);


### PR DESCRIPTION
This is continuous of #202. It seems that `libxml-ruby` still has warnings about "undefining the allocator of T_DATA class " and this PR fixes all that remains.