### PR TITLE
fix: Fix warnings about allocators of T_DATA classes

### DIFF
--- a/ext/libxml/ruby_xml_attributes.c
+++ b/ext/libxml/ruby_xml_attributes.c
@@ -263,6 +263,8 @@ static VALUE rxml_attributes_first(VALUE self)
 void rxml_init_attributes(void)
 {
   cXMLAttributes = rb_define_class_under(mXML, "Attributes", rb_cObject);
+  rb_undef_alloc_func(cXMLAttributes);
+
   rb_include_module(cXMLAttributes, rb_mEnumerable);
   rb_define_method(cXMLAttributes, "node", rxml_attributes_node_get, 0);
   rb_define_method(cXMLAttributes, "get_attribute", rxml_attributes_get_attribute, 1);

--- a/ext/libxml/ruby_xml_xpath_object.c
+++ b/ext/libxml/ruby_xml_xpath_object.c
@@ -322,6 +322,8 @@ static VALUE rxml_xpath_object_debug(VALUE self)
 void rxml_init_xpath_object(void)
 {
   cXMLXPathObject = rb_define_class_under(mXPath, "Object", rb_cObject);
+  rb_undef_alloc_func(cXMLXPathObject);
+
   rb_include_module(cXMLXPathObject, rb_mEnumerable);
   rb_define_attr(cXMLXPathObject, "context", 1, 0);
   rb_define_method(cXMLXPathObject, "each", rxml_xpath_object_each, 0);


### PR DESCRIPTION
- undefining the allocator of T_DATA class LibXML::XML::XPath::Object
- undefining the allocator of T_DATA class LibXML::XML::Attributes

There are other classes that are missing the allocator which I can fix as well but I did not observe them in my application, so I left them alone unless requested.