### PR TITLE
Fix compiling with libxml 2.12.x

### DIFF
--- a/ext/libxml/ruby_libxml.h
+++ b/ext/libxml/ruby_libxml.h
@@ -5,6 +5,7 @@
 
 #include <ruby.h>
 #include <libxml/xmlversion.h>
+#include <libxml/parser.h>
 
 #include "ruby_xml_version.h"
 #include "ruby_xml.h"


### PR DESCRIPTION
Before:

```
❯ gem install libxml-ruby
Building native extensions. This could take a while...
ERROR:  Error installing libxml-ruby:
        ERROR: Failed to build gem native extension.

    current directory: /home/hartley/.cache/asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-4.1.2/ext/libxml
/home/hartley/.cache/asdf/installs/ruby/3.3.0/bin/ruby extconf.rb
checking for libxml/xmlversion.h in /opt/include/libxml2,/opt/local/include/libxml2,/opt/homebrew/opt/libxml2/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2,/usr/local/include,/usr/local/opt/libxml2/include/libxml2... yes
checking for xmlParseDoc() in -lxml2... yes
creating extconf.h
creating Makefile

current directory: /home/hartley/.cache/asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-4.1.2/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20231230-282081-ekb713 sitelibdir\=./.gem.20231230-282081-ekb713 clean

current directory: /home/hartley/.cache/asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-4.1.2/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20231230-282081-ekb713 sitelibdir\=./.gem.20231230-282081-ekb713
compiling libxml.c
In file included from ruby_libxml.h:13,
                 from libxml.c:1:
ruby_xml_encoding.h:12:27: error: unknown type name ‘xmlChar’
   12 | VALUE rxml_new_cstr(const xmlChar* xstr, const xmlChar* xencoding);
      |                           ^~~~~~~
ruby_xml_encoding.h:12:48: error: unknown type name ‘xmlChar’
   12 | VALUE rxml_new_cstr(const xmlChar* xstr, const xmlChar* xencoding);
      |                                                ^~~~~~~
ruby_xml_encoding.h:13:31: error: unknown type name ‘xmlChar’
   13 | VALUE rxml_new_cstr_len(const xmlChar* xstr, const long length, const xmlChar* xencoding);
      |                               ^~~~~~~
ruby_xml_encoding.h:13:71: error: unknown type name ‘xmlChar’
   13 | VALUE rxml_new_cstr_len(const xmlChar* xstr, const long length, const xmlChar* xencoding);
      |                                                                       ^~~~~~~
ruby_xml_encoding.h:15:60: error: unknown type name ‘xmlCharEncoding’
   15 | rb_encoding* rxml_xml_encoding_to_rb_encoding(VALUE klass, xmlCharEncoding xmlEncoding);
      |                                                            ^~~~~~~~~~~~~~~
ruby_xml_encoding.h:16:41: error: unknown type name ‘xmlChar’
   16 | rb_encoding* rxml_figure_encoding(const xmlChar* xencoding);
      |                                         ^~~~~~~
In file included from ruby_libxml.h:14:
ruby_xml_attributes.h:9:27: error: unknown type name ‘xmlNodePtr’
    9 | VALUE rxml_attributes_new(xmlNodePtr xnode);
      |                           ^~~~~~~~~~
In file included from ruby_libxml.h:15:
ruby_xml_attr.h:9:22: error: unknown type name ‘xmlAttrPtr’
    9 | VALUE rxml_attr_wrap(xmlAttrPtr xattr);
      |                      ^~~~~~~~~~
In file included from ruby_libxml.h:16:
ruby_xml_attr_decl.h:9:27: error: unknown type name ‘xmlAttributePtr’
    9 | VALUE rxml_attr_decl_wrap(xmlAttributePtr xattribute);
      |                           ^~~~~~~~~~~~~~~
In file included from ruby_libxml.h:17:
ruby_xml_document.h:8:26: error: unknown type name ‘xmlDocPtr’; did you mean ‘xmlErrorPtr’?
    8 | VALUE rxml_document_wrap(xmlDocPtr xnode);
      |                          ^~~~~~~~~
      |                          xmlErrorPtr
ruby_xml_document.h:10:9: error: unknown type name ‘xmlChar’
   10 | typedef xmlChar * xmlCharPtr;
      |         ^~~~~~~
In file included from ruby_libxml.h:18:
ruby_xml_node.h:9:21: error: unknown type name ‘xmlNodePtr’
    9 | void rxml_node_mark(xmlNodePtr xnode);
      |                     ^~~~~~~~~~
ruby_xml_node.h:10:22: error: unknown type name ‘xmlNodePtr’
   10 | VALUE rxml_node_wrap(xmlNodePtr xnode);
      |                      ^~~~~~~~~~
ruby_xml_node.h:11:23: error: unknown type name ‘xmlNodePtr’
   11 | void rxml_node_manage(xmlNodePtr xnode, VALUE node);
      |                       ^~~~~~~~~~
ruby_xml_node.h:12:25: error: unknown type name ‘xmlNodePtr’
   12 | void rxml_node_unmanage(xmlNodePtr xnode, VALUE node);
      |                         ^~~~~~~~~~
In file included from ruby_libxml.h:19:
ruby_xml_namespace.h:9:27: error: unknown type name ‘xmlNsPtr’; did you mean ‘xmlCharPtr’?
    9 | VALUE rxml_namespace_wrap(xmlNsPtr xns);
      |                           ^~~~~~~~
      |                           xmlCharPtr
In file included from ruby_libxml.h:29:
ruby_xml_sax2_handler.h:6:8: error: unknown type name ‘xmlSAXHandler’
    6 | extern xmlSAXHandler rxml_sax_handler;
      |        ^~~~~~~~~~~~~
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
make: *** [Makefile:248: libxml.o] Error 1

make failed, exit code 2
```

The errors were fixed locally by adding
- an include for libxml/tree.h to ruby_xml_attributes.h
- includes for libxml/xmlstring.h and libxml/encoding.h to ruby_xml_encoding.h

However, this approach generally seems brittle compared to including libxml2/parser.h in the entrypoint which includes all of these headers.

---

I really have no idea what I'm doing, I have basically no experience with C extensions 😅 any feedback is appreciated