### PR TITLE
Support `xmlStructuredErrorFunc` definition change in libxml2

### DIFF
--- a/ext/libxml/ruby_xml_error.c
+++ b/ext/libxml/ruby_xml_error.c
@@ -97,7 +97,7 @@ VALUE rxml_error_wrap(const xmlError *xerror)
 }
 
 /* Hook that receives xml error message */
-static void structuredErrorFunc(void *userData, const xmlError *xerror)
+static void structuredErrorFunc(void *userData, xmlError *xerror)
 {
   VALUE error = rxml_error_wrap(xerror);
 


### PR DESCRIPTION
This pull request supports `xmlStructuredErrorFunc` definition change in libxml2 via https://gitlab.gnome.org/GNOME/libxml2/-/commit/61034116d0a3c8b295c6137956adc3ae55720711

Fix #213 
Thank you for providing a way to fix https://bugs.freebsd.org/bugzilla/attachment.cgi?id=248824&action=diff