### PR TITLE
Add optional zlib support detection in extconf

### DIFF
--- a/ext/libxml/extconf.rb
+++ b/ext/libxml/extconf.rb
@@ -63,5 +63,10 @@ if !found_header || !found_lib
     EOL
 end
 
+# Optional zlib support via libxml2; defines HAVE_ZLIB_H if available.
+unless have_header("zlib.h")
+  message "zlib not found: building without compression support\n"
+end
+
 create_header()
 create_makefile('libxml_ruby')


### PR DESCRIPTION
Hello,

This adds detection for optional zlib support that may be available indirectly through libxml2, to `extconf.rb`.

Background:
While this gem doesn't directly depend on zlib, it can leverage zlib functionality when available through libxml2.  Currently, the `HAVE_ZLIB_H` macro is never defined, which means zlib support is always disabled even when zlib is actually available via libxml2.  This change allows the extension to conditionally use zlib features.

Thank you.